### PR TITLE
Add loop control panel with stop/start/quit functionality

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -19,7 +19,7 @@ builds:
       - amd64
       - arm64
     ldflags:
-      - -s -w -X main.version={{.Version}}
+      - -s -w
 
 archives:
   - id: ralph

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,10 @@
+.PHONY: build test clean
+
+build:
+	go build -o ralph ./cmd/ralph
+
+test:
+	go test ./...
+
+clean:
+	rm -f ralph ralph-test


### PR DESCRIPTION
## Summary
- Add interactive control panel to TUI footer with Stop Loop, Start Loop, and Quit options
- Implement immediate loop interrupt/pause with resume capability
- Add visual status indicators: centered RUNNING/STOPPED title, red border when stopped, Status field in Loop Details
- Add Makefile for streamlined build workflow

## Changes
- `internal/tui/tui.go`: Control panel UI, keyboard navigation (up/down/enter), status indicators
- `internal/loop/loop.go`: Pause/Resume functionality with immediate interrupt
- `cmd/ralph/main.go`: Wire up loop reference to TUI, reorder initialization
- `Makefile`: build, test, clean targets
- `.goreleaser.yaml`: Clean up ldflags

## Test plan
- [x] Run `make build` and verify binary builds
- [x] Launch ralph and verify control panel appears in third footer block
- [x] Test up/down navigation between options
- [x] Test Stop Loop interrupts current iteration immediately
- [x] Test Start Loop resumes from where it stopped
- [x] Test Quit exits the application
- [x] Verify RUNNING/STOPPED status displays correctly