### PR TITLE
Fix elapsed time not pausing when loop is stopped

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -9,7 +9,7 @@ import (
 
 // Default values for configuration
 const (
-	DefaultIterations = 20
+	DefaultIterations = 5
 	DefaultSpecFolder = "specs/"
 )
 


### PR DESCRIPTION
## Summary
- Elapsed timer now freezes when the loop is paused/stopped and resumes from where it left off when started again
- Reduces default loop iterations from 20 to 5

## Test plan
- [x] Build passes
- [x] All tests pass
- [x] Manual test: Start loop, stop it, verify timer freezes
- [x] Manual test: Resume loop, verify timer continues from paused value
- [x] Manual test: Quit while paused, restart, verify elapsed persists correctly