### PR TITLE
feat: build prompt needs adjustment

### DIFF
--- a/internal/prompt/assets/prompt.md
+++ b/internal/prompt/assets/prompt.md
@@ -17,3 +17,4 @@ ULTIMATE GOAL: $ultimate_goal_placeholder_sentence. Keep this goal in mind throu
 9999999. For any bugs you notice, resolve them or document them in @IMPLEMENTATION_PLAN.md using a subagent even if it is unrelated to the current piece of work.
 99999999. Implement functionality completely. Placeholders and stubs waste efforts and time redoing the same work.
 999999999. IMPORTANT: Keep @AGENTS.md operational only — status updates and progress notes belong in `IMPLEMENTATION_PLAN.md`. A bloated AGENTS.md pollutes every future loop's context.
+9999999999. No matter what DON'T commit ./specs/ or ./IMPLEMENTATION_PLAN.md during the work.


### PR DESCRIPTION
Closes #25

## Implementation Plan

**Goal:** Add a rule to the build prompt that prevents committing ./specs/ or ./IMPLEMENTATION_PLAN.md during work.

**Approach:** Locate the build prompt file, identify the existing numbering scheme, and append a new rule with a sufficiently high number (e.g., 999xxx) to ensure it appears at the very end of the prompt instructions.

---

### TASK 1: Locate and update the build prompt
**Milestone:** Build prompt file contains the new rule as the last numbered instruction

- [x] Find the build prompt file in the codebase
- [x] Identify the current highest numbered instruction
- [x] Add new instruction with number format that ensures it's last (e.g., 999xxxx or similar)
- [x] New instruction text: "No matter what DON'T commit ./specs/ or ./IMPLEMENTATION_PLAN.md during the work."

---

### Verification
- [x] New rule is present at the end of the build prompt
- [x] Number is high enough to be the last instruction
- [x] Existing prompt content is unchanged

---

*This PR uses iterative implementation. Tasks are completed one at a time.*