### PR TITLE
feat: ralph needs to display current repo name + branch

### DIFF
--- a/cmd/ralph/main.go
+++ b/cmd/ralph/main.go
@@ -372,6 +372,7 @@ func main() {
 	model.SetLoopProgress(0, cfg.Iterations)
 	model.SetLoop(claudeLoop)
 	model.SetTmuxStatusBar(tmuxBar)
+	model.SetGitContext(dbCtx.repo, dbCtx.branch)
 
 	// Parse implementation plan for task counts
 	completedTasks, totalTasks := parseTaskCounts(cfg.PlanFile)
@@ -1128,6 +1129,7 @@ func runPlanAndBuild(cfg *config.Config, tokenStats *stats.TokenStats, logFile i
 	model.SetBaseElapsed(time.Duration(tokenStats.TotalElapsedNs))
 	model.SetLoopProgress(0, cfg.Iterations)
 	model.SetTmuxStatusBar(tmuxBar)
+	model.SetGitContext(dbCtx.repo, dbCtx.branch)
 
 	// Parse implementation plan for task counts
 	completedTasks, totalTasks := parseTaskCounts(cfg.PlanFile)

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -63,9 +63,9 @@ func (s *StatusBar) Restore() {
 }
 
 // FormatStatusRight builds the tmux status bar content string.
-func FormatStatusRight(loopDisplay, tokenDisplay, timeDisplay string) string {
-	return fmt.Sprintf("[current loop: %s   tokens: %s   elapsed: %s]",
-		loopDisplay, tokenDisplay, timeDisplay)
+func FormatStatusRight(repo, branch, loopDisplay, timeDisplay string) string {
+	return fmt.Sprintf("[%s | %s | loop: %s, uptime: %s]",
+		repo, branch, loopDisplay, timeDisplay)
 }
 
 // IsInsideTmux returns true if the current process is running inside a tmux session.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -167,6 +167,8 @@ type Model struct {
 	tmuxBar           tmuxBarUpdater
 	hibernating       bool      // whether loop is hibernating due to rate limit
 	hibernateUntil    time.Time // when rate limit resets
+	repoName          string    // git repo name for tmux status bar
+	branchName        string    // git branch name for tmux status bar
 }
 
 // NewModel creates and returns a new initialized Model
@@ -221,6 +223,12 @@ func (m *Model) SetBaseElapsed(d time.Duration) {
 // SetTmuxStatusBar sets the tmux status bar manager for live tmux status updates
 func (m *Model) SetTmuxStatusBar(sb tmuxBarUpdater) {
 	m.tmuxBar = sb
+}
+
+// SetGitContext sets the repo and branch names for the tmux status bar
+func (m *Model) SetGitContext(repo, branch string) {
+	m.repoName = repo
+	m.branchName = branch
 }
 
 // SetCompletedTasks sets the completed/total task counts from the implementation plan
@@ -833,26 +841,24 @@ func (m Model) updateTmuxStatusBar() {
 		}
 		mins := int(remaining.Minutes())
 		secs := int(remaining.Seconds()) % 60
-		hibernateDisplay := fmt.Sprintf("💤 %02d:%02d", mins, secs)
-		m.tmuxBar.Update(tmux.FormatStatusRight("RATE LIMITED", hibernateDisplay, ""))
+		hibernateDisplay := fmt.Sprintf("RATE LIMITED 💤 %02d:%02d", mins, secs)
+		m.tmuxBar.Update(tmux.FormatStatusRight(m.repoName, m.branchName, hibernateDisplay, ""))
 		return
 	}
 
-	loopDisplay := "#0/0"
+	loopDisplay := "0/0"
 	if m.totalLoops > 0 {
-		loopDisplay = fmt.Sprintf("#%d/%d", m.currentLoop, m.totalLoops)
+		loopDisplay = fmt.Sprintf("%d/%d", m.currentLoop, m.totalLoops)
 	}
 
-	// Per-loop tokens and elapsed time (not cumulative)
-	tokenDisplay := stats.FormatTokens(m.loopTotalTokens)
-
-	loopElapsed := m.getLoopElapsed()
-	hours := int(loopElapsed.Hours())
-	minutes := int(loopElapsed.Minutes()) % 60
-	seconds := int(loopElapsed.Seconds()) % 60
+	// Total session uptime
+	elapsed := m.getElapsed()
+	hours := int(elapsed.Hours())
+	minutes := int(elapsed.Minutes()) % 60
+	seconds := int(elapsed.Seconds()) % 60
 	timeDisplay := fmt.Sprintf("%02d:%02d:%02d", hours, minutes, seconds)
 
-	m.tmuxBar.Update(tmux.FormatStatusRight(loopDisplay, tokenDisplay, timeDisplay))
+	m.tmuxBar.Update(tmux.FormatStatusRight(m.repoName, m.branchName, loopDisplay, timeDisplay))
 }
 
 // SendMessage is a helper command to send a message to the TUI

--- a/tests/bdd_tmux_test.go
+++ b/tests/bdd_tmux_test.go
@@ -3,17 +3,17 @@ package tests
 // ============================================================================
 // BDD Test Suite: Tmux Status Bar Content (Task 8)
 //
-// User goal: while ralph is running inside tmux, the status bar shows current
-// loop progress, per-loop token count, and per-loop elapsed time so the user
-// can monitor build progress at a glance without looking at the TUI.
+// User goal: while ralph is running inside tmux, the status bar shows repo name,
+// branch, loop progress, and session uptime so the user can monitor build
+// progress at a glance without looking at the TUI.
 //
 // updateTmuxStatusBar() is called on every tick and formats the content as:
 //
-//	[current loop: #N/M   tokens: X   elapsed: HH:MM:SS]
+//	[repo | branch | loop: N/M, uptime: HH:MM:SS]
 //
 // During hibernation it shows:
 //
-//	[current loop: RATE LIMITED   tokens: 💤 MM:SS   elapsed: ]
+//	[repo | branch | RATE LIMITED 💤 MM:SS]
 //
 // These tests inject a FakeStatusBarForTest, trigger a tick, and assert the
 // content passed to the fake bar matches expectations.
@@ -62,8 +62,8 @@ func TestBDD_TmuxStatusBar_LoopProgressShownOnTick(t *testing.T) {
 	triggerTick(m)
 
 	// Then: loop progress shown
-	if !strings.Contains(fakeBar.LastContent, "#2/5") {
-		t.Errorf("Expected #2/5 in tmux bar, got: %q", fakeBar.LastContent)
+	if !strings.Contains(fakeBar.LastContent, "2/5") {
+		t.Errorf("Expected 2/5 in tmux bar, got: %q", fakeBar.LastContent)
 	}
 }
 
@@ -83,38 +83,41 @@ func TestBDD_TmuxStatusBar_DefaultProgressShownBeforeLoopSet(t *testing.T) {
 	triggerTick(m)
 
 	// Then: default loop progress shown
-	if !strings.Contains(fakeBar.LastContent, "#0/0") {
-		t.Errorf("Expected #0/0 in tmux bar before loop is set, got: %q", fakeBar.LastContent)
+	if !strings.Contains(fakeBar.LastContent, "0/0") {
+		t.Errorf("Expected 0/0 in tmux bar before loop is set, got: %q", fakeBar.LastContent)
 	}
 }
 
-// --- Scenario 3: Per-loop token count shown ---
+// --- Scenario 3: Repo and branch shown ---
 
-// TestBDD_TmuxStatusBar_PerLoopTokenCountShownOnTick
+// TestBDD_TmuxStatusBar_RepoBranchShownOnTick
 //
-// Given: a model with 2500 per-loop tokens accumulated
+// Given: a model with git context set (repo="myrepo", branch="feat-x")
 // When: a tick occurs
-// Then: the tmux bar content includes "2.5k" (per-loop, not cumulative)
-func TestBDD_TmuxStatusBar_PerLoopTokenCountShownOnTick(t *testing.T) {
+// Then: the tmux bar content includes the repo and branch names
+func TestBDD_TmuxStatusBar_RepoBranchShownOnTick(t *testing.T) {
 	m, fakeBar := setupModelWithFakeBar(1, 3)
 
-	// Given: 2500 tokens in current loop
-	m, _ = sendTuiMsg(m, tui.SendLoopStatsUpdate(2500))
+	// Given: git context set
+	m.SetGitContext("myrepo", "feat-x")
 
 	// When: tick
 	triggerTick(m)
 
-	// Then: per-loop token count shown
-	if !strings.Contains(fakeBar.LastContent, "2.5k") {
-		t.Errorf("Expected 2.5k in tmux bar, got: %q", fakeBar.LastContent)
+	// Then: repo and branch shown
+	if !strings.Contains(fakeBar.LastContent, "myrepo") {
+		t.Errorf("Expected 'myrepo' in tmux bar, got: %q", fakeBar.LastContent)
+	}
+	if !strings.Contains(fakeBar.LastContent, "feat-x") {
+		t.Errorf("Expected 'feat-x' in tmux bar, got: %q", fakeBar.LastContent)
 	}
 }
 
-// --- Scenario 4: Per-loop elapsed time shown ---
+// --- Scenario 4: Session uptime shown ---
 
 // TestBDD_TmuxStatusBar_ElapsedTimeShownOnTick
 //
-// Given: a model where 65 seconds have elapsed in the current loop (mocked time)
+// Given: a model where 65 seconds of session uptime have elapsed (mocked time)
 // When: a tick occurs
 // Then: the tmux bar content includes "00:01:05"
 func TestBDD_TmuxStatusBar_ElapsedTimeShownOnTick(t *testing.T) {
@@ -215,31 +218,34 @@ func TestBDD_TmuxStatusBar_NoUpdateWhenBarNotSet(t *testing.T) {
 
 // TestBDD_TmuxStatusBar_FullFormatContainsAllFields
 //
-// Given: a model with loop at #3/7, 1000 tokens, 0 elapsed
+// Given: a model with loop at 3/7, git context set, 0 elapsed
 // When: a tick occurs
-// Then: the tmux bar uses the expected format with all three fields present
+// Then: the tmux bar uses the expected format with all fields present
 func TestBDD_TmuxStatusBar_FullFormatContainsAllFields(t *testing.T) {
 	m, fakeBar := setupModelWithFakeBar(3, 7)
-	m, _ = sendTuiMsg(m, tui.SendLoopStatsUpdate(1000))
+	m.SetGitContext("ralph", "main")
 
 	// When: tick
 	triggerTick(m)
 
-	// Then: all three fields present in correct format
+	// Then: all fields present in correct format
 	content := fakeBar.LastContent
-	if !strings.Contains(content, "current loop:") {
-		t.Errorf("Expected 'current loop:' label in tmux bar, got: %q", content)
+	if !strings.Contains(content, "loop:") {
+		t.Errorf("Expected 'loop:' label in tmux bar, got: %q", content)
 	}
-	if !strings.Contains(content, "tokens:") {
-		t.Errorf("Expected 'tokens:' label in tmux bar, got: %q", content)
+	if !strings.Contains(content, "uptime:") {
+		t.Errorf("Expected 'uptime:' label in tmux bar, got: %q", content)
 	}
-	if !strings.Contains(content, "elapsed:") {
-		t.Errorf("Expected 'elapsed:' label in tmux bar, got: %q", content)
+	if !strings.Contains(content, "3/7") {
+		t.Errorf("Expected '3/7' in tmux bar, got: %q", content)
 	}
-	if !strings.Contains(content, "#3/7") {
-		t.Errorf("Expected '#3/7' in tmux bar, got: %q", content)
+	if !strings.Contains(content, " | ") {
+		t.Errorf("Expected ' | ' separator in tmux bar, got: %q", content)
 	}
-	if !strings.Contains(content, "1k") {
-		t.Errorf("Expected '1k' token count in tmux bar, got: %q", content)
+	if !strings.Contains(content, "ralph") {
+		t.Errorf("Expected 'ralph' repo name in tmux bar, got: %q", content)
+	}
+	if !strings.Contains(content, "main") {
+		t.Errorf("Expected 'main' branch name in tmux bar, got: %q", content)
 	}
 }

--- a/tests/tmux_test.go
+++ b/tests/tmux_test.go
@@ -154,8 +154,8 @@ func TestStatusBarNilSafe(t *testing.T) {
 
 // TestFormatStatusRight tests the status bar format string
 func TestFormatStatusRight(t *testing.T) {
-	result := tmux.FormatStatusRight("#1/5", "128.58m", "07:18:00")
-	expected := "[current loop: #1/5   tokens: 128.58m   elapsed: 07:18:00]"
+	result := tmux.FormatStatusRight("ralph", "main", "1/5", "07:18:00")
+	expected := "[ralph | main | loop: 1/5, uptime: 07:18:00]"
 	if result != expected {
 		t.Errorf("FormatStatusRight() = %q, want %q", result, expected)
 	}
@@ -163,11 +163,11 @@ func TestFormatStatusRight(t *testing.T) {
 
 // TestFormatStatusRight_ZeroValues tests formatting with zero/default values
 func TestFormatStatusRight_ZeroValues(t *testing.T) {
-	result := tmux.FormatStatusRight("#0/0", "0", "00:00:00")
+	result := tmux.FormatStatusRight("", "", "0/0", "00:00:00")
 	if result == "" {
 		t.Error("FormatStatusRight should return non-empty string for zero values")
 	}
-	expected := "[current loop: #0/0   tokens: 0   elapsed: 00:00:00]"
+	expected := "[ |  | loop: 0/0, uptime: 00:00:00]"
 	if result != expected {
 		t.Errorf("FormatStatusRight() = %q, want %q", result, expected)
 	}


### PR DESCRIPTION
Closes #48

# Display Repo + Branch in Tmux Status Bar Implementation Plan

## Overview

Replace the current tmux status bar format `[current loop: #N/M   tokens: X   elapsed: HH:MM:SS]` with `[repo | branch | loop: N/M, uptime: HH:MM:SS]`. This adds git context (repo name and branch) to the bar, drops token count, switches to total session uptime, and removes the `#` prefix from the loop counter.

## Current State Analysis

### Key Discoveries:
- `tmux.FormatStatusRight(loopDisplay, tokenDisplay, timeDisplay string)` at `internal/tmux/tmux.go:66-68` is the single format point — changing its signature cascades to all callers
- `updateTmuxStatusBar()` at `internal/tui/tui.go:822-856` is the only caller of `FormatStatusRight`; it runs every 250ms tick
- `stats.GetGitContext()` at `internal/stats/stats.go:186-202` already returns `(owner, repo, branch)` — called in `cmd/ralph/main.go:77` and stored in `dbContext.repo` / `dbContext.branch`
- The TUI `Model` struct (`internal/tui/tui.go:135-170`) has **no** repo/branch fields — they must be added alongside existing setter pattern (`SetLoopProgress`, `SetBaseElapsed`, etc.)
- Two model setup sites in main.go: `runBuild` (~line 369) and `runPlanAndBuild` (~line 1126) — both need `SetGitContext` wired in
- Hibernation path in `updateTmuxStatusBar()` (line 837) calls `FormatStatusRight("RATE LIMITED", hibernateDisplay, "")` — must be updated to new signature
- Tests in `tests/tmux_test.go:155-174` (`TestFormatStatusRight`, `TestFormatStatusRight_ZeroValues`) assert the old format — must be updated
- BDD tests in `tests/bdd_tmux_test.go` assert for `#N/M`, `"current loop:"`, `"tokens:"`, `"elapsed:"` labels — all must be updated

## Desired End State

After implementation, when ralph runs inside tmux, the status bar shows:
```
[ralph | my-feature-branch | loop: 2/5, uptime: 00:07:42]
```

During rate-limit hibernation:
```
[ralph | my-feature-branch | RATE LIMITED 💤 03:30]
```

Verification: `go test -v ./tests/ ./cmd/ralph/` passes with zero failures.

## What We're NOT Doing

- Not showing `owner` (GitHub org/user) in the status bar — the spec only shows `repo` and `branch`
- Not removing `loopTotalTokens` field or `SendLoopStatsUpdate` from the model — those may be used elsewhere; just stop consuming them in the tmux path
- Not changing the TUI footer panels — the "Usage & Cost" and "Loop Details" panels are out of scope

## Implementation Approach

Update `FormatStatusRight` signature → propagate the compile error to `updateTmuxStatusBar` → fix that method (add fields, change logic) → add `SetGitContext` setter → wire it in main.go → fix tests. The compiler will catch all missed call sites.

---

**IMPORTANT: Checkboxes are for implementation steps only.** Steps requiring manual human verification (browser testing, manual QA, visual inspection, staging verification, human review) MUST NOT be checkboxes — place them in the numbered "Manual Testing Steps" section at the bottom of the plan instead.

### TASK 1: Update `FormatStatusRight` signature and format string [HIGH PRIORITY]
**Status:** COMPLETED
**Milestone:** The tmux format function reflects the new `[repo | branch | loop: N/M, uptime: HH:MM:SS]` contract

- [x] In `internal/tmux/tmux.go:66-68`, change the function signature from `FormatStatusRight(loopDisplay, tokenDisplay, timeDisplay string)` to `FormatStatusRight(repo, branch, loopDisplay, timeDisplay string)`
- [x] Update the `fmt.Sprintf` format string from `"[current loop: %s   tokens: %s   elapsed: %s]"` to `"[%s | %s | loop: %s, uptime: %s]"`
- [x] Verify the file compiles (the caller in `tui.go` will now fail to compile — that is expected and handled in Task 2)

**Validation:** `go build ./internal/tmux/` succeeds; the format string change is visible in the source.

**Requirements from spec:**
- Display format: `[repo | branch | loop: x/y, uptime: $this_run_time]`
- Remove tokens display
- Change "elapsed:" label to "uptime:"

**Files to Modify:**
- `internal/tmux/tmux.go` — change `FormatStatusRight` signature (drop `tokenDisplay`, add `repo`, `branch`) and update format string

---

### TASK 2: Add `repoName`/`branchName` fields to `Model` and add `SetGitContext` setter [HIGH PRIORITY]
**Status:** COMPLETED
**Milestone:** The TUI model can store and expose git context for the status bar

- [x] In `internal/tui/tui.go`, add `repoName string` and `branchName string` fields to the `Model` struct (after the `hibernateUntil` field around line 169)
- [x] Add a `SetGitContext(repo, branch string)` method on `*Model` following the same pattern as `SetCurrentMode` and `SetCurrentTask`

**Validation:** `go build ./internal/tui/` succeeds (after Task 3 also fixes the `FormatStatusRight` call).

**Requirements from spec:**
- Repo name and branch must be available at the point `updateTmuxStatusBar()` runs

**Files to Modify:**
- `internal/tui/tui.go` — add `repoName`, `branchName` fields to `Model` struct; add `SetGitContext` setter method

---

### TASK 3: Update `updateTmuxStatusBar()` to use new format [HIGH PRIORITY]
**Status:** COMPLETED
**Milestone:** The tmux bar is updated every tick with the correct new format

- [x] In `internal/tui/tui.go:updateTmuxStatusBar()`, change the normal-state loop display from `fmt.Sprintf("#%d/%d", ...)` to `fmt.Sprintf("%d/%d", ...)` (drop the `#` prefix)
- [x] Remove the `tokenDisplay` computation lines (the `stats.FormatTokens(m.loopTotalTokens)` call)
- [x] Switch the time display from `m.getLoopElapsed()` to `m.getElapsed()` (total session uptime, not per-loop)
- [x] Update the normal-state `FormatStatusRight` call to pass `m.repoName, m.branchName, loopDisplay, timeDisplay`
- [x] Update the hibernation path (`if m.hibernating` block): change the `FormatStatusRight` call to use a combined loop display of `"RATE LIMITED 💤 MM:SS"` as the `loopDisplay` argument and pass `m.repoName, m.branchName` — i.e., `tmux.FormatStatusRight(m.repoName, m.branchName, fmt.Sprintf("RATE LIMITED %s", hibernateDisplay), "")` — or equivalently, produce `[repo | branch | RATE LIMITED 💤 MM:SS]` by passing `timeDisplay` as empty
- [x] Also update the default `loopDisplay` fallback from `"#0/0"` to `"0/0"` when `m.totalLoops == 0`

**Validation:** `go build ./internal/tui/` succeeds with no compile errors.

**Requirements from spec:**
- Format: `[repo | branch | loop: x/y, uptime: $this_run_time]`
- No `#` prefix on loop counter
- Total session uptime, not per-loop

**Files to Modify:**
- `internal/tui/tui.go` — rewrite `updateTmuxStatusBar()` body as described

---

### TASK 4: Wire `SetGitContext` into both model setup sites in `cmd/ralph/main.go` [HIGH PRIORITY]
**Status:** COMPLETED
**Milestone:** Both `runBuild` and `runPlanAndBuild` pass repo/branch to the TUI model at startup

- [x] In `cmd/ralph/main.go` inside `runBuild` (around line 374), add `model.SetGitContext(dbCtx.repo, dbCtx.branch)` after the existing `model.SetTmuxStatusBar(tmuxBar)` call
- [x] In `cmd/ralph/main.go` inside `runPlanAndBuild` (around line 1130), add the same `model.SetGitContext(dbCtx.repo, dbCtx.branch)` call after `model.SetTmuxStatusBar(tmuxBar)`

**Validation:** `go build -o ralph ./cmd/ralph` succeeds; no compile errors.

**Requirements from spec:**
- Repo and branch must be populated in the model so they appear in the status bar

**Files to Modify:**
- `cmd/ralph/main.go` — add `model.SetGitContext(dbCtx.repo, dbCtx.branch)` in `runBuild` and `runPlanAndBuild`

---

### TASK 5: Update unit tests in `tests/tmux_test.go` [MEDIUM PRIORITY]
**Status:** COMPLETED
**Milestone:** Unit tests for `FormatStatusRight` pass with the new signature and expected output

- [x] In `tests/tmux_test.go:TestFormatStatusRight` (line 156), update the call to `tmux.FormatStatusRight("ralph", "main", "1/5", "07:18:00")` and update `expected` to `"[ralph | main | loop: 1/5, uptime: 07:18:00]"`
- [x] In `tests/tmux_test.go:TestFormatStatusRight_ZeroValues` (line 165), update the call to `tmux.FormatStatusRight("", "", "0/0", "00:00:00")` and update `expected` to `"[ |  | loop: 0/0, uptime: 00:00:00]"`

**Validation:** `go test -v -run TestFormatStatusRight ./tests/` passes.

**Requirements from spec:**
- Tests must reflect the new format

**Files to Modify:**
- `tests/tmux_test.go` — update both `TestFormatStatusRight` tests for new signature and expected values

---

### TASK 6: Update BDD tests in `tests/bdd_tmux_test.go` [MEDIUM PRIORITY]
**Status:** COMPLETED
**Milestone:** All BDD tmux status bar tests pass with the new format

- [x] Update Scenario 1 (`TestBDD_TmuxStatusBar_LoopProgressShownOnTick`): change the assertion from `#2/5` to `2/5`
- [x] Update Scenario 2 (`TestBDD_TmuxStatusBar_DefaultProgressShownBeforeLoopSet`): change the assertion from `#0/0` to `0/0`
- [x] Update Scenario 3 (`TestBDD_TmuxStatusBar_PerLoopTokenCountShownOnTick`): tokens are no longer in the tmux bar — replace this test to assert that repo/branch appear in the bar (e.g., set git context on model and verify `fakeBar.LastContent` contains the repo and branch strings). Update the test description accordingly.
- [x] Update Scenario 4 (`TestBDD_TmuxStatusBar_ElapsedTimeShownOnTick`): the time shown is now total session uptime not per-loop elapsed, but `00:01:05` is still valid since the model `startTime` is set to `baseTime` at creation — verify the assertion still matches; update comment to say "uptime" not "per-loop elapsed"
- [x] Update Scenario 8 (`TestBDD_TmuxStatusBar_FullFormatContainsAllFields`): remove assertions for `"current loop:"`, `"tokens:"`, `"elapsed:"`; add assertions for `"loop:"`, `"uptime:"`, and for the `3/7` loop count (without `#`); add assertions for repo/branch separator `" | "` being present in the content

**Validation:** `go test -v -run TestBDD_TmuxStatusBar ./tests/` passes with all scenarios green.

**Requirements from spec:**
- BDD tests must reflect the new status bar format and behavior

**Files to Modify:**
- `tests/bdd_tmux_test.go` — update assertions in Scenarios 1, 2, 3, 4, and 8 as described above

---

## Testing Strategy

### Unit Tests:
- `TestFormatStatusRight` — verifies the exact format string output `[repo | branch | loop: N/M, uptime: HH:MM:SS]`
- `TestFormatStatusRight_ZeroValues` — verifies non-empty output with empty/zero values

### Integration Tests:
- `TestBDD_TmuxStatusBar_LoopProgressShownOnTick` — loop counter without `#` prefix
- `TestBDD_TmuxStatusBar_DefaultProgressShownBeforeLoopSet` — default `0/0` shown before loop starts
- `TestBDD_TmuxStatusBar_PerLoopTokenCountShownOnTick` (repurposed) — repo/branch appears in bar
- `TestBDD_TmuxStatusBar_ElapsedTimeShownOnTick` — uptime shows correct HH:MM:SS
- `TestBDD_TmuxStatusBar_RateLimitedLabelShownDuringHibernate` — RATE LIMITED shown
- `TestBDD_TmuxStatusBar_SleepEmojiCountdownShownDuringHibernate` — countdown shown
- `TestBDD_TmuxStatusBar_FullFormatContainsAllFields` — all new fields present

### Manual Testing Steps:
1. Run `ralph build` inside a tmux session and verify the status bar shows `[<repo> | <branch> | loop: 1/5, uptime: 00:00:XX]`
2. Pause and resume the loop with `p`/`r`, confirm uptime freezes/resumes correctly
3. Trigger rate-limit hibernation (or mock it) and verify the bar shows `[<repo> | <branch> | RATE LIMITED 💤 MM:SS]`
4. Run outside tmux and verify no panic / no visible change

## Performance Considerations

No performance implications — the change is purely in string formatting within an already-running 250ms tick callback.
