### PR TITLE
feat: 529 hibernate causes loop to advance

### DIFF
--- a/cmd/ralph/main.go
+++ b/cmd/ralph/main.go
@@ -672,6 +672,27 @@ func handleParsedMessage(
 		return // Don't process further
 	}
 
+	// Check for API 500 (server error) — enter hibernate state with exponential backoff
+	if jsonParser.IsAPIServerError(parsed) {
+		backoffDuration, retryNum, exceeded := apiBackoff.Next()
+		if exceeded {
+			msgChan <- tui.Message{
+				Role:    tui.RoleHibernate,
+				Content: fmt.Sprintf("API server error (500): max retries (%d) exceeded, stopping loop", apiBackoff.MaxRetries()),
+			}
+			claudeLoop.Stop()
+			return
+		}
+		resetsAt := time.Now().Add(backoffDuration)
+		claudeLoop.Hibernate(resetsAt)
+		program.Send(tui.SendHibernate(resetsAt)())
+		msgChan <- tui.Message{
+			Role:    tui.RoleHibernate,
+			Content: fmt.Sprintf("API server error (500), retry %d/%d, hibernating %s until %s", retryNum, apiBackoff.MaxRetries(), backoffDuration.Round(time.Second), resetsAt.Format(time.Kitchen)),
+		}
+		return // Don't process further
+	}
+
 	// Check for authentication error — stop loop with helpful message
 	if jsonParser.IsAuthenticationError(parsed) {
 		if os.Getenv("ANTHROPIC_API_KEY") != "" {
@@ -872,6 +893,20 @@ func handleParsedMessageCLI(
 		resetsAt := time.Now().Add(backoffDuration)
 		claudeLoop.Hibernate(resetsAt)
 		fmt.Printf("[hibernate] API overloaded (529), retry %d/%d, hibernating %s until %s\n", retryNum, apiBackoff.MaxRetries(), backoffDuration.Round(time.Second), resetsAt.Format(time.Kitchen))
+		return
+	}
+	// Check for API 500 (server error) — enter hibernate state with exponential backoff
+	if jsonParser.IsAPIServerError(parsed) {
+		backoffDuration, retryNum, exceeded := apiBackoff.Next()
+		if exceeded {
+			fmt.Printf("[hibernate] API server error (500): max retries (%d) exceeded, stopping loop\n", apiBackoff.MaxRetries())
+			claudeLoop.Stop()
+			return
+		}
+		resetsAt := time.Now().Add(backoffDuration)
+		claudeLoop.Hibernate(resetsAt)
+		fmt.Printf("[hibernate] API server error (500), retry %d/%d, hibernating %s until %s\n", retryNum, apiBackoff.MaxRetries(), backoffDuration.Round(time.Second), resetsAt.Format(time.Kitchen))
+		return
 	}
 	// Check for authentication error — stop loop with helpful message
 	if jsonParser.IsAuthenticationError(parsed) {

--- a/cmd/ralph/main.go
+++ b/cmd/ralph/main.go
@@ -599,7 +599,7 @@ func processMessage(
 // Shared by processMessage, processPlanPhase, and processBuildPhase.
 func handleLoopMarker(msg loop.Message, msgChan chan<- tui.Message, program *tea.Program, loopTotalTokens *int64, iterEstimate *float64, subagentCostAccum *float64, iterToolUseCount *int, dbCtx *dbContext, lt *loopTracker, tokenStats *stats.TokenStats, seenMsgIDs map[string]bool) {
 	program.Send(tui.SendLoopUpdate(msg.Loop, msg.Total)())
-	// Detect new loop iteration start (not STOPPED/COMPLETED/RESUMED)
+	// Detect new loop iteration start (not STOPPED/COMPLETED/RESUMED/RETRY)
 	if isNewLoopStart(msg.Content) {
 		lt.startNewLoop(dbCtx, tokenStats, msg.Loop)
 		*loopTotalTokens = 0
@@ -609,6 +609,13 @@ func handleLoopMarker(msg loop.Message, msgChan chan<- tui.Message, program *tea
 		clear(seenMsgIDs)
 		program.Send(tui.SendLoopStarted()())
 		program.Send(tui.SendLoopStatsUpdate(0)())
+	} else if isRetryLoopStart(msg.Content) {
+		// Hibernate retry: reset iteration counters but do NOT create a new DB entry
+		// and do NOT reset apiBackoff (callers handle that separately)
+		*loopTotalTokens = 0
+		*iterEstimate = 0
+		*subagentCostAccum = 0
+		*iterToolUseCount = 0
 	}
 	// Use stop sign emoji for STOPPED messages
 	role := tui.RoleLoop
@@ -1097,6 +1104,12 @@ func runCLI(cfg *config.Config, promptContent string, tokenStats *stats.TokenSta
 					iterToolUseCount = 0
 					seenMsgIDs = make(map[string]bool)
 					apiBackoff.Reset()
+				} else if isRetryLoopStart(msg.Content) {
+					// Hibernate retry: reset iteration counters but do NOT create
+					// a new DB entry and do NOT reset apiBackoff
+					iterEstimate = 0
+					subagentCostAccum = 0
+					iterToolUseCount = 0
 				}
 				fmt.Printf("[loop] %s\n", msg.Content)
 
@@ -1720,7 +1733,14 @@ func isNewLoopStart(content string) bool {
 	return strings.Contains(content, "LOOP") &&
 		!strings.Contains(content, "STOPPED") &&
 		!strings.Contains(content, "COMPLETED") &&
-		!strings.Contains(content, "RESUMED")
+		!strings.Contains(content, "RESUMED") &&
+		!strings.Contains(content, "RETRY")
+}
+
+// isRetryLoopStart returns true when the loop marker indicates a hibernate retry
+// (the iteration is being retried after a 529/500 hibernate, not a fresh start).
+func isRetryLoopStart(content string) bool {
+	return strings.Contains(content, "LOOP") && strings.Contains(content, "RETRY")
 }
 
 // parseTaskCounts reads an IMPLEMENTATION_PLAN.md file and returns the number of

--- a/cmd/ralph/main_test.go
+++ b/cmd/ralph/main_test.go
@@ -622,3 +622,93 @@ func TestExitLoopDetection_ThresholdConstant(t *testing.T) {
 		t.Error("noopCostThreshold must be positive")
 	}
 }
+
+// TestAPIBackoffNotResetOnHibernateRetry verifies that when a RETRY loop marker
+// arrives after a 529 hit, apiBackoff is NOT reset — the consecutive hit counter
+// should continue escalating across the retry cycle.
+func TestAPIBackoffNotResetOnHibernateRetry(t *testing.T) {
+	apiBackoff := loop.NewBackoff()
+
+	// Step 1: fresh loop start → reset backoff
+	freshContent := "======= LOOP 1/5 ======="
+	if !isNewLoopStart(freshContent) {
+		t.Fatal("expected isNewLoopStart to be true for fresh loop")
+	}
+	apiBackoff.Reset()
+	if apiBackoff.ConsecutiveHits() != 0 {
+		t.Fatalf("expected consecutiveHits=0 after reset, got %d", apiBackoff.ConsecutiveHits())
+	}
+
+	// Step 2: 529 hit → backoff.Next() increments counter
+	_, retryNum, exceeded := apiBackoff.Next()
+	if exceeded {
+		t.Fatal("did not expect exceeded on first hit")
+	}
+	if retryNum != 1 {
+		t.Fatalf("expected retryNum=1, got %d", retryNum)
+	}
+	if apiBackoff.ConsecutiveHits() != 1 {
+		t.Fatalf("expected consecutiveHits=1 after Next(), got %d", apiBackoff.ConsecutiveHits())
+	}
+
+	// Step 3: RETRY loop marker arrives — isNewLoopStart should return false,
+	// so apiBackoff.Reset() should NOT be called
+	retryContent := "======= LOOP 1/5 (RETRY) ======="
+	if isNewLoopStart(retryContent) {
+		t.Fatal("expected isNewLoopStart to be false for RETRY marker")
+	}
+	if !isRetryLoopStart(retryContent) {
+		t.Fatal("expected isRetryLoopStart to be true for RETRY marker")
+	}
+	// Simulate what the real code does: only reset on isNewLoopStart
+	if isNewLoopStart(retryContent) {
+		apiBackoff.Reset() // should NOT execute
+	}
+
+	// Step 4: verify backoff was NOT reset — consecutive hits still 1
+	if apiBackoff.ConsecutiveHits() != 1 {
+		t.Errorf("expected consecutiveHits=1 (not reset on RETRY), got %d", apiBackoff.ConsecutiveHits())
+	}
+}
+
+// TestStartNewLoopNotCalledOnHibernateRetry verifies that when a RETRY loop marker
+// arrives, the code path that calls startNewLoop() is NOT reached. We verify this by
+// checking that isNewLoopStart returns false for RETRY content, which is the gate
+// that prevents startNewLoop from being called in handleLoopMarker and runCLI.
+func TestStartNewLoopNotCalledOnHibernateRetry(t *testing.T) {
+	// Track whether startNewLoop would be called via the isNewLoopStart gate
+	startNewLoopCallCount := 0
+
+	// Simulate a fresh loop start — isNewLoopStart returns true → startNewLoop would be called
+	freshContent := "======= LOOP 1/5 ======="
+	if isNewLoopStart(freshContent) {
+		startNewLoopCallCount++
+	}
+	if startNewLoopCallCount != 1 {
+		t.Fatalf("expected startNewLoop to be called once for fresh loop, got %d", startNewLoopCallCount)
+	}
+
+	// Simulate a RETRY marker — isNewLoopStart returns false → startNewLoop NOT called
+	retryContent := "======= LOOP 1/5 (RETRY) ======="
+	if isNewLoopStart(retryContent) {
+		startNewLoopCallCount++
+	}
+
+	if startNewLoopCallCount != 1 {
+		t.Errorf("expected startNewLoop call count to remain 1 after RETRY marker, got %d", startNewLoopCallCount)
+	}
+
+	// Verify isRetryLoopStart returns true — the retry path is taken instead
+	if !isRetryLoopStart(retryContent) {
+		t.Error("expected isRetryLoopStart to be true for RETRY marker")
+	}
+
+	// A subsequent fresh loop start SHOULD increment the counter again
+	freshContent2 := "======= LOOP 2/5 ======="
+	if isNewLoopStart(freshContent2) {
+		startNewLoopCallCount++
+	}
+	if startNewLoopCallCount != 2 {
+		t.Errorf("expected startNewLoop call count=2 after second fresh loop, got %d", startNewLoopCallCount)
+	}
+}

--- a/cmd/ralph/main_test.go
+++ b/cmd/ralph/main_test.go
@@ -274,12 +274,35 @@ func TestHandleLoopMarkerReturnsTrue(t *testing.T) {
 		{"======= STOPPED =======", false},
 		{"======= COMPLETED 5 ITERATIONS =======", false},
 		{"======= RESUMED =======", false},
+		{"======= LOOP 1/5 (RETRY) =======", false},
+		{"======= LOOP 3/5 (RETRY) =======", false},
 	}
 
 	for _, tt := range tests {
 		isLoopStart := isNewLoopStart(tt.content)
 		if isLoopStart != tt.expected {
 			t.Errorf("isNewLoopStart(%q) = %v, want %v", tt.content, isLoopStart, tt.expected)
+		}
+	}
+}
+
+func TestIsRetryLoopStart(t *testing.T) {
+	tests := []struct {
+		content  string
+		expected bool
+	}{
+		{"======= LOOP 1/5 (RETRY) =======", true},
+		{"======= LOOP 3/5 (RETRY) =======", true},
+		{"======= LOOP 1/5 =======", false},
+		{"======= STOPPED =======", false},
+		{"======= COMPLETED 5 ITERATIONS =======", false},
+		{"======= RESUMED =======", false},
+	}
+
+	for _, tt := range tests {
+		result := isRetryLoopStart(tt.content)
+		if result != tt.expected {
+			t.Errorf("isRetryLoopStart(%q) = %v, want %v", tt.content, result, tt.expected)
 		}
 	}
 }

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -259,6 +259,7 @@ func (l *Loop) run(ctx context.Context) {
 	}()
 
 	i := 1
+	isHibernateRetry := false
 	for {
 		// Inner loop: run iterations until we catch up with GetIterations()
 		for ; i <= l.GetIterations(); i++ {
@@ -296,9 +297,14 @@ func (l *Loop) run(ctx context.Context) {
 
 			// Send loop marker
 			total := l.GetIterations()
+			markerContent := fmt.Sprintf("======= LOOP %d/%d =======", i, total)
+			if isHibernateRetry {
+				markerContent = fmt.Sprintf("======= LOOP %d/%d (RETRY) =======", i, total)
+				isHibernateRetry = false
+			}
 			l.output <- Message{
 				Type:    "loop_marker",
-				Content: fmt.Sprintf("======= LOOP %d/%d =======", i, total),
+				Content: markerContent,
 				Loop:    i,
 				Total:   total,
 			}
@@ -370,6 +376,7 @@ func (l *Loop) run(ctx context.Context) {
 					Total:   total,
 				}
 				// Retry this iteration
+				isHibernateRetry = true
 				i--
 				continue
 			}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -7,6 +7,12 @@ import (
 	"time"
 )
 
+// APIError represents a structured API error object (e.g., from 500 responses)
+type APIError struct {
+	Type    string `json:"type"`
+	Message string `json:"message"`
+}
+
 // MessageType represents the type of Claude message
 type MessageType string
 
@@ -16,6 +22,7 @@ const (
 	MessageTypeUser      MessageType = "user"
 	MessageTypeResult    MessageType = "result"
 	MessageTypeRateLimit MessageType = "rate_limit_event"
+	MessageTypeAPIError  MessageType = "error"
 	MessageTypeUnknown   MessageType = "unknown"
 )
 
@@ -71,9 +78,9 @@ type ParsedMessage struct {
 	TotalCostUSD    float64        `json:"total_cost_usd,omitempty"`
 	CostUSD         float64        `json:"cost_usd,omitempty"`
 	ParentToolUseID *string        `json:"parent_tool_use_id,omitempty"`
-	IsError         bool           `json:"is_error,omitempty"`
-	Error           string         `json:"error,omitempty"`
-	RateLimitInfo   *RateLimitInfo `json:"rate_limit_info,omitempty"`
+	IsError         bool              `json:"is_error,omitempty"`
+	ErrorRaw        json.RawMessage   `json:"error,omitempty"`
+	RateLimitInfo   *RateLimitInfo    `json:"rate_limit_info,omitempty"`
 	RawJSON         string         `json:"-"` // Original JSON for debugging
 }
 
@@ -328,6 +335,28 @@ func (p *Parser) IsRateLimitRejected(msg *ParsedMessage) (bool, time.Time) {
 	return true, time.Unix(msg.RateLimitInfo.ResetsAt, 0)
 }
 
+// GetError returns the error message string from a ParsedMessage, handling both
+// string-form errors (529s) and object-form errors (500s).
+func (msg *ParsedMessage) GetError() string {
+	if msg == nil || len(msg.ErrorRaw) == 0 {
+		return ""
+	}
+
+	// Try string form first (e.g., 529: "error": "API error 529: Overloaded")
+	var errStr string
+	if err := json.Unmarshal(msg.ErrorRaw, &errStr); err == nil {
+		return errStr
+	}
+
+	// Try object form (e.g., 500: "error": {"type": "api_error", "message": "Internal server error"})
+	var apiErr APIError
+	if err := json.Unmarshal(msg.ErrorRaw, &apiErr); err == nil {
+		return apiErr.Message
+	}
+
+	return ""
+}
+
 // IsAPIOverloaded checks if message indicates an API 529 (overloaded) error.
 // Returns true if the message has is_error set and the error string contains
 // "529" or "overloaded" (case-insensitive).
@@ -335,8 +364,25 @@ func (p *Parser) IsAPIOverloaded(msg *ParsedMessage) bool {
 	if msg == nil || !msg.IsError {
 		return false
 	}
-	errLower := strings.ToLower(msg.Error)
+	errLower := strings.ToLower(msg.GetError())
 	return strings.Contains(errLower, "529") || strings.Contains(errLower, "overloaded")
+}
+
+// IsAPIServerError checks if message indicates an API 500 server error.
+// Returns true when the message type is "error" and the error object has
+// type "api_error". These have is_error absent/false, so we check message type instead.
+func (p *Parser) IsAPIServerError(msg *ParsedMessage) bool {
+	if msg == nil || len(msg.ErrorRaw) == 0 {
+		return false
+	}
+	if msg.Type != MessageTypeAPIError {
+		return false
+	}
+	var apiErr APIError
+	if err := json.Unmarshal(msg.ErrorRaw, &apiErr); err != nil {
+		return false
+	}
+	return apiErr.Type == "api_error"
 }
 
 // IsAuthenticationError checks if message indicates an authentication error.
@@ -344,10 +390,14 @@ func (p *Parser) IsAPIOverloaded(msg *ParsedMessage) bool {
 // Checks both is_error messages (result type) and assistant messages where
 // the error field is set without is_error (e.g. "authentication_failed").
 func (p *Parser) IsAuthenticationError(msg *ParsedMessage) bool {
-	if msg == nil || msg.Error == "" {
+	if msg == nil {
 		return false
 	}
-	errLower := strings.ToLower(msg.Error)
+	errStr := msg.GetError()
+	if errStr == "" {
+		return false
+	}
+	errLower := strings.ToLower(errStr)
 	return strings.Contains(errLower, "authentication") ||
 		strings.Contains(errLower, "unauthorized") ||
 		strings.Contains(errLower, "invalid_api_key") ||

--- a/tests/loop_test.go
+++ b/tests/loop_test.go
@@ -2123,3 +2123,63 @@ func TestHibernateRetryDecrementIteration(t *testing.T) {
 		t.Errorf("Expected at least 2 loop starts after hibernate (retry + next), got %d", loopStartCount)
 	}
 }
+
+// TestHibernateRetryEmitsRetryMarker tests that after a hibernate+retry cycle,
+// the retried iteration emits a loop_marker containing "(RETRY)" in its content.
+func TestHibernateRetryEmitsRetryMarker(t *testing.T) {
+	cfg := loop.Config{
+		Iterations:     2,
+		Prompt:         "test",
+		CommandBuilder: mockMediumSlowCommandBuilder,
+		SleepDuration:  10 * time.Millisecond,
+	}
+
+	l := loop.New(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	l.Start(ctx)
+	output := l.Output()
+
+	// Wait for first iteration to start (system message arrives before sleep)
+	for msg := range output {
+		if msg.Type == "output" && strings.Contains(msg.Content, `"type":"system"`) {
+			break
+		}
+	}
+
+	// Hibernate briefly while the iteration is still running
+	l.Hibernate(time.Now().Add(50 * time.Millisecond))
+
+	// Collect all loop_marker messages after hibernate
+	retryMarkerFound := false
+	normalMarkerAfterRetry := false
+	completed := false
+	for msg := range output {
+		if msg.Type == "loop_marker" {
+			if strings.Contains(msg.Content, "(RETRY)") {
+				retryMarkerFound = true
+			} else if retryMarkerFound && strings.Contains(msg.Content, "LOOP") &&
+				!strings.Contains(msg.Content, "HIBERNATING") &&
+				!strings.Contains(msg.Content, "WAKING") &&
+				!strings.Contains(msg.Content, "COMPLETED") {
+				// A normal LOOP marker after the RETRY marker = next iteration
+				normalMarkerAfterRetry = true
+			}
+		}
+		if msg.Type == "complete" {
+			completed = true
+			cancel()
+		}
+	}
+
+	if !retryMarkerFound {
+		t.Error("Expected a loop_marker containing '(RETRY)' after hibernate+retry cycle")
+	}
+	if !completed {
+		t.Error("Expected loop to complete all iterations")
+	}
+	if !normalMarkerAfterRetry {
+		t.Error("Expected a normal LOOP marker after the RETRY marker (second iteration)")
+	}
+}

--- a/tests/parser_test.go
+++ b/tests/parser_test.go
@@ -1189,8 +1189,8 @@ func TestIsRateLimitRejectedPattern2(t *testing.T) {
 	if !msg.IsError {
 		t.Error("Expected IsError=true")
 	}
-	if msg.Error != "rate_limit" {
-		t.Errorf("Expected Error='rate_limit', got %q", msg.Error)
+	if msg.GetError() != "rate_limit" {
+		t.Errorf("Expected GetError()='rate_limit', got %q", msg.GetError())
 	}
 
 	rejected, resetTime := p.IsRateLimitRejected(msg)
@@ -1776,5 +1776,75 @@ func TestIterationCostDisplaySuppressedForSubagent(t *testing.T) {
 				t.Errorf("Expected shouldDisplay=%v, got %v", tt.shouldDisplay, wouldDisplay)
 			}
 		})
+	}
+}
+
+// TestIsAPIServerError_Detects500Error tests detection of 500 API server errors
+func TestIsAPIServerError_Detects500Error(t *testing.T) {
+	p := parser.NewParser()
+	line := `{"type":"error","error":{"type":"api_error","message":"Internal server error"},"request_id":"req_abc123"}`
+	msg := p.ParseLine(line)
+
+	if msg == nil {
+		t.Fatal("Expected non-nil parsed message")
+	}
+
+	if !p.IsAPIServerError(msg) {
+		t.Error("Expected IsAPIServerError=true for 500 api_error response")
+	}
+}
+
+// TestIsAPIServerError_DoesNotDetect529 tests that 529 errors don't trigger IsAPIServerError
+func TestIsAPIServerError_DoesNotDetect529(t *testing.T) {
+	p := parser.NewParser()
+	line := `{"type":"assistant","is_error":true,"error":"API error 529: Overloaded"}`
+	msg := p.ParseLine(line)
+
+	if msg == nil {
+		t.Fatal("Expected non-nil parsed message")
+	}
+
+	if p.IsAPIServerError(msg) {
+		t.Error("Expected IsAPIServerError=false for 529 error (should not double-trigger)")
+	}
+}
+
+// TestGetError_StringForm tests GetError with string-form error (529)
+func TestGetError_StringForm(t *testing.T) {
+	p := parser.NewParser()
+	line := `{"type":"assistant","is_error":true,"error":"API error 529: Overloaded"}`
+	msg := p.ParseLine(line)
+
+	if msg == nil {
+		t.Fatal("Expected non-nil parsed message")
+	}
+
+	errStr := msg.GetError()
+	if errStr != "API error 529: Overloaded" {
+		t.Errorf("Expected GetError()='API error 529: Overloaded', got %q", errStr)
+	}
+}
+
+// TestGetError_ObjectForm tests GetError with object-form error (500)
+func TestGetError_ObjectForm(t *testing.T) {
+	p := parser.NewParser()
+	line := `{"type":"error","error":{"type":"api_error","message":"Internal server error"}}`
+	msg := p.ParseLine(line)
+
+	if msg == nil {
+		t.Fatal("Expected non-nil parsed message")
+	}
+
+	errStr := msg.GetError()
+	if errStr != "Internal server error" {
+		t.Errorf("Expected GetError()='Internal server error', got %q", errStr)
+	}
+}
+
+// TestIsAPIServerError_NilMessage tests nil message returns false
+func TestIsAPIServerError_NilMessage(t *testing.T) {
+	p := parser.NewParser()
+	if p.IsAPIServerError(nil) {
+		t.Error("Expected IsAPIServerError=false for nil message")
 	}
 }


### PR DESCRIPTION
Closes #53

# Hibernate Loop Retry Bugs Implementation Plan

## Overview

Three bugs exist in the 529 hibernation and API error handling paths. When the loop retries after a 529 hibernate, `isNewLoopStart()` can't distinguish a hibernate retry from a fresh loop start, causing: (1) `apiBackoff` being reset mid-retry sequence, defeating exponential backoff; and (2) `startNewLoop()` creating duplicate DB cost entries for the same iteration. Additionally, (3) API 500 "Internal Server Error" responses have a different JSON structure that escapes the existing error detection entirely, causing the loop to advance without retry.

## Current State Analysis

### Key Discoveries:
- `loop.go:374-375`: `i--; continue` correctly retries the same iteration number after hibernate — loop counter is NOT the bug
- `loop.go:297-304`: After the `continue`, the inner for-loop re-emits `"======= LOOP N/M ======="` at the top of the next iteration — this is indistinguishable from a fresh start
- `main.go:1512-1517`: `isNewLoopStart()` returns `true` for any "LOOP" content not containing "STOPPED", "COMPLETED", or "RESUMED" — it has no hibernate-retry awareness
- `main.go:527-529`, `952-957`, `1384-1385`, `1479-1480`: All four message-processing paths call `apiBackoff.Reset()` on `isNewLoopStart()` match — each incorrectly resets backoff on retry
- `main.go:572-573`, `952-953`: `startNewLoop()` is called on every `isNewLoopStart()` match — on retry, this calls `completeLoop()` on the interrupted iteration creating a bogus DB entry, then starts a new tracking entry for the same iteration number
- `parser.go:65-77`: `ParsedMessage.Error` is `string` — when a 500 error arrives with `"error": {"type":"api_error",...}` (object), the field fails to unmarshal and stays empty
- `parser.go:333-338`: `IsAPIOverloaded()` requires `msg.IsError == true` — 500 errors have `is_error` absent/false, so they fall through with no retry

## Desired End State

After this plan is implemented:
1. When the API returns 529 back-to-back across a hibernate/retry cycle, `apiBackoff` correctly escalates (30s → 60s → 120s...) instead of resetting to 30s each time
2. The DB contains exactly one loop stats entry per unique iteration, with no partial-cost ghost entries from hibernate-interrupted runs
3. API 500 "Internal Server Error" responses trigger the same hibernate+exponential-backoff behavior as 529 errors (up to the same `maxRetries=8` limit)

Verify with: `go test -v ./tests/ ./cmd/ralph/`

## What We're NOT Doing

- Not fixing the pause/resume retry path (calling `startNewLoop()` on resume appears intentional — the user explicitly restarted the iteration)
- Not changing how the TUI displays the HIBERNATING/WAKING markers
- Not adding a new DB schema or migration — cost entries simply won't be created for interrupted iterations
- Not making 500 errors use a different retry limit than 529s (same `maxRetries=8`)

## Implementation Approach

**For Bugs #1 & #2** (hibernate retry side effects): Use Option A from the research — emit a distinct `"======= LOOP N/M (RETRY) ======="` marker from `loop.go` for hibernate retries, then update `isNewLoopStart()` to exclude "RETRY" content. This naturally prevents both `apiBackoff.Reset()` and `startNewLoop()` calls at all four call sites with minimal changes. A new `isRetryLoopStart()` helper resets iteration counters (iterEstimate, subagentCostAccum, iterToolUseCount, loopTotalTokens) for the retry without creating a DB entry.

**For Bug #3** (500 errors): Add a `json.RawMessage` field to `ParsedMessage` to capture the polymorphic "error" JSON (string for 529s, object for 500s). Rename the existing `Error string` field to avoid the JSON tag conflict. Add `GetError()` to return the error text regardless of form. Add `IsAPIServerError()` to detect 500 api_error responses. Apply the same hibernate+backoff logic for 500s as for 529s in all message-handling paths.

---

**IMPORTANT: Checkboxes are for implementation steps only.**

### TASK 1: Fix ParsedMessage to Handle 500 Error JSON Structure [HIGH PRIORITY]
**Status:** NOT STARTED
**Milestone:** `parser.go` correctly parses both string-error (529) and object-error (500) JSON, and `IsAPIServerError()` reliably identifies 500 api_error messages

- [x] Add `APIError` struct to `internal/parser/parser.go` with `Type string` and `Message string` fields (json tags `"type"` and `"message"`)
- [x] Rename `Error string` field in `ParsedMessage` to `ErrorStr string` with json tag `json:"-"` (remove from JSON unmarshaling)
- [x] Add `ErrorRaw json.RawMessage` field to `ParsedMessage` with json tag `json:"error,omitempty"` to capture both string and object forms
- [x] Add `GetError() string` method on `*ParsedMessage` that tries to unmarshal `ErrorRaw` as string first, then as `APIError` object, returning the message string in either case
- [x] Update `IsAPIOverloaded()` in `parser.go:333-338` to use `msg.GetError()` instead of `msg.Error`
- [x] Add `IsAPIServerError(msg *ParsedMessage) bool` method to `Parser` that returns `true` when `msg.Type == "error"` AND the `ErrorRaw` unmarshals to an `APIError` with `Type == "api_error"`
- [x] Add `MessageTypeAPIError MessageType = "error"` constant to the `MessageType` enum in `parser.go`

**Validation:** `go test -v ./tests/` — parser tests pass; new tests for 500 JSON detection pass

**Requirements from spec:**
- 500 error JSON has `{"type":"error","error":{"type":"api_error","message":"Internal server error"}}` structure
- `is_error` is absent (false) in 500 errors — detection cannot rely on it
- Must not break existing 529 error detection which uses string-form `"error"` field

**Files to Modify:**
- `internal/parser/parser.go` — add `APIError` struct, replace `Error string` with `ErrorRaw json.RawMessage`, add `GetError()`, add `IsAPIServerError()`, add `MessageTypeAPIError` constant

---

### TASK 2: Apply 500 Error Hibernate Logic in All Message Handlers [HIGH PRIORITY]
**Status:** NOT STARTED
**Milestone:** 500 API errors in all code paths (TUI, CLI, plan-and-build) trigger hibernate+backoff instead of silently advancing the loop

- [x] In `handleParsedMessage()` at `main.go:620-638` (TUI mode): add an `else if jsonParser.IsAPIServerError(parsed)` block that calls `apiBackoff.Next()`, hibernates with the computed backoff duration, sends hibernate TUI message and loop stop on max retries exceeded — matching the existing 529 block structure exactly
- [x] In `handleParsedMessageCLI()` at `main.go:788-804` (CLI mode): add the same `IsAPIServerError()` check with `apiBackoff.Next()`, `claudeLoop.Hibernate()`, and `fmt.Printf` output — matching the existing CLI 529 block structure
- [x] Ensure both handlers use `return` after handling the 500 error (same as 529 handlers) to prevent further message processing for that message

**Validation:** `go test -v ./cmd/ralph/` — new tests for 500 hibernate behavior pass; `go build -o ralph ./cmd/ralph` compiles

**Requirements from spec:**
- 500 errors should use the same `apiBackoff` with the same `maxRetries=8` limit as 529 errors
- The 500 error should hibernate the loop (not advance to the next iteration)
- In TUI mode: send `tui.SendHibernate()` and a `tui.RoleHibernate` message to the activity feed
- In CLI mode: print `[hibernate]` prefixed output to stdout

**Files to Modify:**
- `cmd/ralph/main.go` lines 620-638 (`handleParsedMessage`) — add 500 error hibernate block
- `cmd/ralph/main.go` lines 788-804 (`handleParsedMessageCLI`) — add 500 error hibernate block

---

### TASK 3: Emit Distinct RETRY Marker from loop.go for Hibernate Retries [HIGH PRIORITY]
**Status:** NOT STARTED
**Milestone:** `loop.go` emits `"======= LOOP N/M (RETRY) ======="` for hibernate retries, allowing callers to distinguish retry from fresh start

- [x] Add `isHibernateRetry bool` local variable initialized to `false` before the inner `for` loop in `loop.go:run()` (around line 264)
- [x] In the hibernate handling block at `loop.go:373-375` (just before `i--; continue`): set `isHibernateRetry = true`
- [x] At the loop marker emit site (`loop.go:297-304`): check `isHibernateRetry` — if true, emit `"======= LOOP %d/%d (RETRY) ======="` and reset `isHibernateRetry = false`; otherwise emit the normal `"======= LOOP %d/%d ======="`
- [x] Verify that the `Loop` and `Total` integer fields on the emitted `Message` struct are unchanged (the integers drive TUI display; the string content drives behavior branching)

**Validation:** Write a test that exercises a hibernate+retry cycle and verifies the second loop_marker message has content containing "(RETRY)"; run `go test -v ./tests/`

**Requirements from spec:**
- Only hibernate retries should emit the RETRY marker — pause/resume retries should continue emitting the normal marker (they use a separate code path at `loop.go:340-342`)
- The `Loop` and `Total` fields must still carry the correct iteration integers for TUI progress display

**Files to Modify:**
- `internal/loop/loop.go` lines 261-374 (`run()`) — add `isHibernateRetry` flag, conditional marker format

---

### TASK 4: Fix isNewLoopStart() and All Call Sites to Respect RETRY Marker [HIGH PRIORITY]
**Status:** NOT STARTED
**Milestone:** `apiBackoff.Reset()` and `startNewLoop()` are NOT called on hibernate retries; iteration counters ARE reset for the retry; all four code paths fixed

- [x] Update `isNewLoopStart()` at `main.go:1512-1517` to add `!strings.Contains(content, "RETRY")` to the return expression
- [x] Add `isRetryLoopStart(content string) bool` helper below `isNewLoopStart()` that returns `strings.Contains(content, "LOOP") && strings.Contains(content, "RETRY")`
- [x] In `handleLoopMarker()` at `main.go:569-590` (TUI shared handler): add an `else if isRetryLoopStart(msg.Content)` block that resets `*loopTotalTokens`, `*iterEstimate`, `*subagentCostAccum`, `*iterToolUseCount` to 0 (but does NOT call `lt.startNewLoop()` and does NOT call `program.Send(tui.SendLoopStarted()())`)
- [x] In `processMessage()` at `main.go:524-529` (TUI mode): the existing `if isNewLoopStart(msg.Content) { apiBackoff.Reset() }` block naturally handles the fix once `isNewLoopStart()` excludes RETRY — no change needed to this block
- [x] In `runCLI()` at `main.go:952-957` (CLI mode): add an `else if isRetryLoopStart(msg.Content)` block that resets `iterEstimate`, `subagentCostAccum`, `iterToolUseCount` to 0 (but does NOT call `lt.startNewLoop()` and does NOT call `apiBackoff.Reset()`)
- [x] In `processPlanPhase()` at `main.go:1384-1385` (plan-and-build TUI plan phase): the existing `if isNewLoopStart(msg.Content) { apiBackoff.Reset() }` block is already correct after `isNewLoopStart()` is updated — no additional change needed
- [x] In `processBuildPhase()` at `main.go:1479-1480` (plan-and-build TUI build phase): same as plan phase — no additional change needed after `isNewLoopStart()` fix
- [x] Update `TestHandleLoopMarkerReturnsTrue` in `cmd/ralph/main_test.go` to add a test case for `"======= LOOP 1/5 (RETRY) ======="` returning `false` from `isNewLoopStart()`

**Validation:** `go test -v ./cmd/ralph/` — all existing tests pass; new RETRY marker test cases pass

**Requirements from spec:**
- `apiBackoff.Reset()` must NOT be called when content contains "RETRY" (the backoff counter should continue escalating across the retry cycle)
- `startNewLoop()` must NOT be called on retry (no new DB entry for the repeated iteration number)
- Iteration counters (iterEstimate, subagentCostAccum, etc.) SHOULD be reset on retry so the retry attempt tracks its own costs cleanly
- `lt.startNewLoop()` IS still called for the TUI plan-and-build phases — they share `handleLoopMarker()` which handles this via the `isNewLoopStart()` fix

**Files to Modify:**
- `cmd/ralph/main.go:1512-1517` (`isNewLoopStart`) — add `!strings.Contains(content, "RETRY")`
- `cmd/ralph/main.go` (after `isNewLoopStart`) — add `isRetryLoopStart()` helper function
- `cmd/ralph/main.go:569-590` (`handleLoopMarker`) — add `else if isRetryLoopStart` counter-reset block
- `cmd/ralph/main.go:950-957` (CLI `loop_marker` case) — add `else if isRetryLoopStart` counter-reset block (no startNewLoop, no apiBackoff.Reset)
- `cmd/ralph/main_test.go` — add RETRY marker test case to `TestHandleLoopMarkerReturnsTrue`

---

### TASK 5: Add Tests for All Three Bugs [MEDIUM PRIORITY]
**Status:** NOT STARTED
**Milestone:** Tests document and prevent regressions for all three bugs

- [x] In `tests/parser_test.go`: add `TestIsAPIServerError_Detects500Error` that calls `parser.IsAPIServerError()` with the exact 500 JSON `{"type":"error","error":{"type":"api_error","message":"Internal server error"},"request_id":"req_..."}` and asserts true
- [x] In `tests/parser_test.go`: add `TestIsAPIServerError_DoesNotDetect529` that calls `IsAPIServerError()` with a 529 `is_error:true` message and asserts false (these should not double-trigger)
- [x] In `tests/parser_test.go`: add `TestGetError_StringForm` that parses a 529 message and verifies `GetError()` returns the error string
- [x] In `tests/parser_test.go`: add `TestGetError_ObjectForm` that parses a 500 message and verifies `GetError()` returns `"Internal server error"` from the nested object
- [x] In `cmd/ralph/main_test.go`: add `TestAPIBackoffNotResetOnHibernateRetry` that simulates: (1) fresh loop start → `apiBackoff.Reset()` (counter=0); (2) 529 hit → `apiBackoff.Next()` (counter=1); (3) RETRY loop marker → `isNewLoopStart()` returns false, `isRetryLoopStart()` returns true, apiBackoff NOT reset; (4) verify `apiBackoff.ConsecutiveHits() == 1` (not 0)
- [x] In `cmd/ralph/main_test.go`: add `TestStartNewLoopNotCalledOnHibernateRetry` that verifies a RETRY marker does NOT call `lt.startNewLoop()` (use a counter or check that `lt.currentLoopID` hasn't changed after the retry marker is processed)
- [x] In `tests/loop_test.go`: add `TestHibernateRetryEmitsRetryMarker` that uses a mock command builder to emit a 529-like response, trigger `Hibernate()`, then wait for the loop to emit a `loop_marker` message containing "(RETRY)" — verifying Task 3's implementation

**Validation:** `go test -v ./tests/ ./cmd/ralph/` — all new tests pass

**Requirements from spec:**
- Test for `apiBackoff` not being reset covers the "should be counter=2, ~60s" scenario from Bug #1's message flow
- Test for `startNewLoop()` covers the "creates a second DB entry for the same loop number" scenario from Bug #2

**Files to Modify:**
- `tests/parser_test.go` — add 4 new parser tests
- `cmd/ralph/main_test.go` — add 2 new main function tests
- `tests/loop_test.go` — add 1 new loop retry marker test

---

## Testing Strategy

### Unit Tests:
- Parser: `IsAPIServerError()` with 500 JSON, `GetError()` for string and object forms, no false positives on 529s
- Main: `isNewLoopStart()` returns false for "(RETRY)" content, `isRetryLoopStart()` returns true for "(RETRY)", `apiBackoff` not reset on retry, `startNewLoop` not called on retry
- Loop: hibernate retry emits "(RETRY)" marker

### Integration Tests:
- `go test -v ./tests/ ./cmd/ralph/` must pass completely after all tasks

### Manual Testing Steps:
1. Run `ralph build` against a project, then trigger a 529 error (or simulate with mock); verify the activity feed shows "API overloaded (529), retry 1/8, hibernating 30s..." then after wake shows "LOOP N/M (RETRY)" and then on second 529 shows "retry 2/8, hibernating ~60s..." (not 30s again)
2. Check the stats DB (`~/.ralph/ralph_stats.db`) after a hibernate+retry cycle and verify only one `loop_stats` entry exists for the retried iteration number (not two)
3. Simulate a 500 error response from the Claude CLI (edit mock or intercept); verify the TUI shows the RATE LIMITED banner with a countdown, not a silent loop advance

## Performance Considerations

No performance implications. The `isRetryLoopStart()` call is a cheap string check on the loop marker content, executed once per loop iteration boundary.