### PR TITLE
feat: ACP-modeled tool-step + plan visualization in the TUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ coverage.out
 # ralph
 IMPLEMENTATION_PLAN.md
 specs/
+
+# ralph runtime artifacts (logs + persisted token stats, any directory)
+.ralph.log
+.claude_stats
+.ralph.claude_stats

--- a/cmd/ralph/main.go
+++ b/cmd/ralph/main.go
@@ -288,6 +288,28 @@ func main() {
 		}
 	}
 
+	// Handle build mode with the embedded prompt: if the spec folder is empty or
+	// missing, write a spec template for the user to fill in and exit, mirroring
+	// the autoresearch template flow.
+	if cfg.IsBuildMode() && cfg.SpecFile == "" && cfg.LoopPrompt == "" && config.SpecFolderEmptyOrMissing(cfg.SpecFolder) {
+		templateContent, tmplErr := prompt.GetEmbeddedSpecTemplate()
+		if tmplErr != nil {
+			fmt.Fprintf(os.Stderr, "Error loading template: %v\n", tmplErr)
+			os.Exit(1)
+		}
+		if mkErr := os.MkdirAll(cfg.SpecFolder, 0755); mkErr != nil {
+			fmt.Fprintf(os.Stderr, "Error creating spec folder %s: %v\n", cfg.SpecFolder, mkErr)
+			os.Exit(1)
+		}
+		templatePath := filepath.Join(cfg.SpecFolder, "spec_template.md")
+		if writeErr := os.WriteFile(templatePath, []byte(templateContent), 0644); writeErr != nil {
+			fmt.Fprintf(os.Stderr, "Error creating template: %v\n", writeErr)
+			os.Exit(1)
+		}
+		fmt.Printf("Created %s\nDescribe your goal and acceptance criteria, then save your spec into %s and run `ralph` again.\n", templatePath, cfg.SpecFolder)
+		return
+	}
+
 	// Wrap in tmux if not already inside one (skip in CLI mode)
 	if !cfg.CLI && tmux.ShouldWrap(cfg.NoTmux) {
 		if err := tmux.Wrap(cfg.Subcommand); err != nil {

--- a/cmd/ralph/main.go
+++ b/cmd/ralph/main.go
@@ -632,6 +632,16 @@ func handleLoopMarker(msg loop.Message, msgChan chan<- tui.Message, program *tea
 	}
 }
 
+// toTUIPlan converts parser PlanItems into the tui package's local PlanItem
+// type (the tui package intentionally has no parser import).
+func toTUIPlan(items []parser.PlanItem) []tui.PlanItem {
+	out := make([]tui.PlanItem, 0, len(items))
+	for _, it := range items {
+		out = append(out, tui.PlanItem{Content: it.Content, Status: string(it.Status)})
+	}
+	return out
+}
+
 // handleParsedMessage processes a parsed JSON message from Claude for TUI mode.
 // Shared by standard mode and plan-and-build mode.
 func handleParsedMessage(
@@ -788,6 +798,13 @@ func handleParsedMessage(
 	case parser.MessageTypeAssistant:
 		content := jsonParser.ExtractContent(parsed)
 
+		// Agent plan (TodoWrite): drive the plan panel + footer counters. The
+		// generic TodoWrite tool row is suppressed below so the plan panel is
+		// the single representation.
+		if len(content.Plan) > 0 {
+			program.Send(tui.SendPlanUpdate(toTUIPlan(content.Plan))())
+		}
+
 		// Display thinking blocks
 		if content.Thinking != "" {
 			msgChan <- tui.Message{
@@ -821,6 +838,12 @@ func handleParsedMessage(
 		// completed/failed when its tool_result arrives (see MessageTypeUser).
 		*iterToolUseCount += len(content.ToolUses)
 		for _, toolUse := range content.ToolUses {
+			// TodoWrite is represented by the plan panel, not a redundant
+			// lifecycle row. It still counts toward iterToolUseCount above so
+			// noop-exit detection is unchanged.
+			if toolUse.Name == "TodoWrite" {
+				continue
+			}
 			toolMsg := toolUse.Title
 			if toolMsg == "" {
 				toolMsg = "Using tool: " + toolUse.Name
@@ -1004,9 +1027,22 @@ func handleParsedMessageCLI(
 				fmt.Fprintf(logFile, "[assistant] %s\n\n", text)
 			}
 		}
+		if len(content.Plan) > 0 {
+			completed := 0
+			for _, it := range content.Plan {
+				if it.Status == parser.PlanCompleted {
+					completed++
+				}
+			}
+			fmt.Printf("[plan] %d/%d done\n", completed, len(content.Plan))
+		}
 		for _, item := range parsed.Message.Content {
 			if item.Type == parser.ContentTypeToolUse {
 				*iterToolUseCount++
+				// TodoWrite is surfaced via the [plan] line above, not a tool row.
+				if item.Name == "TodoWrite" {
+					continue
+				}
 				kind := parser.ClassifyToolKind(item.Name)
 				filePath := parser.ExtractFilePathFromInput(item.Input)
 				if filePath != "" {

--- a/cmd/ralph/main.go
+++ b/cmd/ralph/main.go
@@ -816,24 +816,40 @@ func handleParsedMessage(
 			}
 		}
 
-		// Display tool uses with file path info and count for noop detection
+		// Display tool uses as ACP-modeled lifecycle rows and count for noop
+		// detection. Each row starts in_progress and is flipped to
+		// completed/failed when its tool_result arrives (see MessageTypeUser).
 		*iterToolUseCount += len(content.ToolUses)
 		for _, toolUse := range content.ToolUses {
-			toolMsg := fmt.Sprintf("Using tool: %s", toolUse.Name)
-			if toolUse.FilePath != "" {
-				toolMsg = fmt.Sprintf("Using tool: %s — %s", toolUse.Name, toolUse.FilePath)
+			toolMsg := toolUse.Title
+			if toolMsg == "" {
+				toolMsg = "Using tool: " + toolUse.Name
+			}
+			if toolUse.Location != "" && !strings.Contains(toolMsg, toolUse.Location) {
+				toolMsg = fmt.Sprintf("%s — %s", toolMsg, toolUse.Location)
 			}
 			msgChan <- tui.Message{
-				Role:    tui.RoleTool,
-				Content: toolMsg,
+				Role:      tui.RoleTool,
+				Content:   toolMsg,
+				ToolUseID: toolUse.ID,
+				Kind:      string(toolUse.Kind),
+				Status:    string(parser.ToolStatusInProgress),
 			}
 		}
 
 	case parser.MessageTypeUser:
 		// Skip tool result content in TUI mode (file dumps are too verbose).
-		// Still scan for task references in the results.
+		// Flip the matching tool row to completed/failed, and still scan for
+		// task references in the results.
 		content := jsonParser.ExtractContent(parsed)
 		for _, toolResult := range content.ToolResults {
+			if toolResult.ToolUseID != "" {
+				status := parser.ToolStatusCompleted
+				if toolResult.IsError {
+					status = parser.ToolStatusFailed
+				}
+				program.Send(tui.SendToolStatusUpdate(toolResult.ToolUseID, string(status))())
+			}
 			if toolResult.Content != "" {
 				if ref := jsonParser.ExtractTaskReference(toolResult.Content); ref != nil {
 					taskLabel := fmt.Sprintf("#%d", ref.Number)
@@ -991,12 +1007,22 @@ func handleParsedMessageCLI(
 		for _, item := range parsed.Message.Content {
 			if item.Type == parser.ContentTypeToolUse {
 				*iterToolUseCount++
+				kind := parser.ClassifyToolKind(item.Name)
 				filePath := parser.ExtractFilePathFromInput(item.Input)
 				if filePath != "" {
-					fmt.Printf("[tool] %s: %s\n", item.Name, filePath)
+					fmt.Printf("[tool] (%s) %s: %s\n", kind, item.Name, filePath)
 				} else {
-					fmt.Printf("[tool] %s\n", item.Name)
+					fmt.Printf("[tool] (%s) %s\n", kind, item.Name)
 				}
+			}
+		}
+	}
+	// Report tool completion/failure in CLI mode.
+	if parsed.Type == parser.MessageTypeUser {
+		content := jsonParser.ExtractContent(parsed)
+		for _, toolResult := range content.ToolResults {
+			if toolResult.IsError {
+				fmt.Printf("[tool] failed\n")
 			}
 		}
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -156,6 +156,33 @@ func (c *Config) IsAutoresearchMode() bool {
 	return c.Subcommand == "autoresearch"
 }
 
+// IsBuildMode returns true for bare `ralph` or the explicit "build" subcommand.
+func (c *Config) IsBuildMode() bool {
+	return c.Subcommand == "" || c.Subcommand == "build"
+}
+
+// SpecFolderEmptyOrMissing reports whether the spec folder does not exist or
+// exists but contains no entries. A path that exists but is not a directory
+// returns false so that validation can surface the more specific error.
+func SpecFolderEmptyOrMissing(path string) bool {
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return false
+	}
+	info, err := os.Stat(absPath)
+	if os.IsNotExist(err) {
+		return true
+	}
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	entries, err := os.ReadDir(absPath)
+	if err != nil {
+		return false
+	}
+	return len(entries) == 0
+}
+
 // Validate checks if the configuration is valid.
 // It validates:
 // - Iterations must be greater than 0

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -36,6 +37,106 @@ const (
 	ContentTypeThinking   ContentType = "thinking"
 )
 
+// ToolKind is a semantic category for a tool call, mirroring the Agent Client
+// Protocol (ACP) tool-call `kind` taxonomy. It drives icon/visual selection in
+// the TUI independent of the concrete Claude tool name.
+type ToolKind string
+
+const (
+	ToolKindRead    ToolKind = "read"
+	ToolKindEdit    ToolKind = "edit"
+	ToolKindDelete  ToolKind = "delete"
+	ToolKindMove    ToolKind = "move"
+	ToolKindSearch  ToolKind = "search"
+	ToolKindExecute ToolKind = "execute"
+	ToolKindThink   ToolKind = "think"
+	ToolKindFetch   ToolKind = "fetch"
+	ToolKindOther   ToolKind = "other"
+)
+
+// ToolStatus is the lifecycle status of a tool call, mirroring the ACP
+// tool-call `status` enum. A tool_use starts in_progress and transitions to
+// completed/failed when its corresponding tool_result arrives.
+type ToolStatus string
+
+const (
+	ToolStatusPending    ToolStatus = "pending"
+	ToolStatusInProgress ToolStatus = "in_progress"
+	ToolStatusCompleted  ToolStatus = "completed"
+	ToolStatusFailed     ToolStatus = "failed"
+)
+
+// ClassifyToolKind maps a Claude tool name to an ACP-style ToolKind.
+// Unknown tools (including MCP tools) fall back to ToolKindOther.
+func ClassifyToolKind(name string) ToolKind {
+	switch name {
+	case "Read", "NotebookRead":
+		return ToolKindRead
+	case "Edit", "MultiEdit", "Write", "NotebookEdit":
+		return ToolKindEdit
+	case "Bash", "BashOutput", "KillBash", "KillShell":
+		return ToolKindExecute
+	case "Glob", "Grep":
+		return ToolKindSearch
+	case "WebFetch", "WebSearch":
+		return ToolKindFetch
+	case "Task":
+		return ToolKindThink
+	default:
+		return ToolKindOther
+	}
+}
+
+// buildToolTitle produces a short, human-readable label for a tool call,
+// e.g. "Read config.go", "Bash: go build ./...", or a Task description.
+func buildToolTitle(name string, kind ToolKind, input map[string]interface{}) string {
+	// Prefer an explicit description for execute/think tools when present.
+	if kind == ToolKindExecute || kind == ToolKindThink {
+		if desc, ok := input["description"].(string); ok && desc != "" {
+			return desc
+		}
+	}
+	switch kind {
+	case ToolKindRead, ToolKindEdit, ToolKindDelete, ToolKindMove:
+		if path := firstString(input, "file_path", "path"); path != "" {
+			return name + " " + filepath.Base(path)
+		}
+	case ToolKindSearch:
+		if pattern, ok := input["pattern"].(string); ok && pattern != "" {
+			return name + " " + truncate(pattern, 50)
+		}
+	case ToolKindExecute:
+		if cmd, ok := input["command"].(string); ok && cmd != "" {
+			return name + ": " + truncate(cmd, 50)
+		}
+	case ToolKindFetch:
+		if url := firstString(input, "url", "query"); url != "" {
+			return name + " " + truncate(url, 50)
+		}
+	}
+	return name
+}
+
+// firstString returns the first non-empty string value among the given keys.
+func firstString(input map[string]interface{}, keys ...string) string {
+	for _, k := range keys {
+		if v, ok := input[k].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+// truncate shortens s to at most n runes, appending an ellipsis if cut.
+// It counts runes (not bytes) so multibyte UTF-8 is never split mid-rune.
+func truncate(s string, n int) string {
+	r := []rune(s)
+	if len(r) <= n {
+		return s
+	}
+	return string(r[:n]) + "..."
+}
+
 // Usage represents token usage information from Claude
 type Usage struct {
 	InputTokens              int64 `json:"input_tokens"`
@@ -61,6 +162,7 @@ type ContentItem struct {
 	ToolUseID      string                 `json:"tool_use_id,omitempty"` // Tool use ID for tool_result
 	Content        interface{}            `json:"content,omitempty"`     // Tool result content
 	ThinkingText   string                 `json:"thinking,omitempty"`    // Thinking content for thinking items
+	IsError        bool                   `json:"is_error,omitempty"`    // True for failed tool_result
 }
 
 // InnerMessage represents the message field within an assistant/user message
@@ -98,16 +200,27 @@ type ParsedContent struct {
 	Thinking    string       // Extracted <thinking> content
 }
 
-// ToolUse represents a tool use from the assistant
+// ToolUse represents a tool use from the assistant.
+// The ACP-modeled fields (ID, Kind, Title, Location) describe the tool call
+// the way the Agent Client Protocol's ToolCall schema does, so the TUI can
+// render a lifecycle-aware row.
 type ToolUse struct {
 	Name      string
-	InputJSON string // Truncated JSON preview
-	FilePath  string // Extracted file path from input (if available)
+	InputJSON string   // Truncated JSON preview
+	FilePath  string   // Extracted file path from input (if available); alias of Location
+	ID        string   // Tool use ID — correlates with the matching ToolResult.ToolUseID
+	Kind      ToolKind // ACP-style semantic kind (read/edit/execute/search/...)
+	Title     string   // Short human-readable label, e.g. "Read config.go"
+	Location  string   // File path / pattern / command the call targets
 }
 
-// ToolResult represents a tool result from the user
+// ToolResult represents a tool result from the user.
+// ToolUseID/IsError let the TUI flip the matching ToolUse row to
+// completed or failed.
 type ToolResult struct {
-	Content string // Truncated content
+	Content   string // Truncated content
+	ToolUseID string // ID of the tool_use this result responds to
+	IsError   bool   // True if the tool call failed
 }
 
 // TaskReference represents a detected IMPLEMENTATION_PLAN.md task reference
@@ -255,10 +368,16 @@ func (p *Parser) ExtractContent(msg *ParsedMessage) *ParsedContent {
 			if len(inputJSON) > 150 {
 				inputJSON = inputJSON[:150]
 			}
+			location := ExtractFilePathFromInput(item.Input)
+			kind := ClassifyToolKind(item.Name)
 			content.ToolUses = append(content.ToolUses, ToolUse{
 				Name:      item.Name,
 				InputJSON: inputJSON,
-				FilePath:  ExtractFilePathFromInput(item.Input),
+				FilePath:  location,
+				ID:        item.ID,
+				Kind:      kind,
+				Title:     buildToolTitle(item.Name, kind, item.Input),
+				Location:  location,
 			})
 
 		case ContentTypeToolResult:
@@ -272,9 +391,14 @@ func (p *Parser) ExtractContent(msg *ParsedMessage) *ParsedContent {
 				}
 			}
 			resultText = p.StripSystemReminders(resultText)
-			if resultText != "" {
+			// Always record a result that carries a tool_use_id so the TUI can
+			// update the matching tool row's status, even when the (stripped)
+			// content is empty.
+			if resultText != "" || item.ToolUseID != "" {
 				content.ToolResults = append(content.ToolResults, ToolResult{
-					Content: resultText,
+					Content:   resultText,
+					ToolUseID: item.ToolUseID,
+					IsError:   item.IsError,
 				})
 			}
 		}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -54,6 +54,24 @@ const (
 	ToolKindOther   ToolKind = "other"
 )
 
+// PlanItemStatus is the status of a single plan entry, mirroring the ACP
+// `plan` session-update entry status. It maps directly to the TodoWrite tool's
+// per-item status field.
+type PlanItemStatus string
+
+const (
+	PlanPending    PlanItemStatus = "pending"
+	PlanInProgress PlanItemStatus = "in_progress"
+	PlanCompleted  PlanItemStatus = "completed"
+)
+
+// PlanItem is one entry in the agent's todo/plan list, synthesized from a
+// TodoWrite tool-use input.
+type PlanItem struct {
+	Content string
+	Status  PlanItemStatus
+}
+
 // ToolStatus is the lifecycle status of a tool call, mirroring the ACP
 // tool-call `status` enum. A tool_use starts in_progress and transitions to
 // completed/failed when its corresponding tool_result arrives.
@@ -80,7 +98,7 @@ func ClassifyToolKind(name string) ToolKind {
 		return ToolKindSearch
 	case "WebFetch", "WebSearch":
 		return ToolKindFetch
-	case "Task":
+	case "Task", "TodoWrite":
 		return ToolKindThink
 	default:
 		return ToolKindOther
@@ -198,6 +216,7 @@ type ParsedContent struct {
 	ToolUses    []ToolUse    // Tool uses
 	ToolResults []ToolResult // Tool results
 	Thinking    string       // Extracted <thinking> content
+	Plan        []PlanItem   // Agent plan, synthesized from a TodoWrite tool_use
 }
 
 // ToolUse represents a tool use from the assistant.
@@ -379,6 +398,12 @@ func (p *Parser) ExtractContent(msg *ParsedMessage) *ParsedContent {
 				Title:     buildToolTitle(item.Name, kind, item.Input),
 				Location:  location,
 			})
+			// A TodoWrite call carries the agent's full plan; synthesize the
+			// ACP-style plan entries from its input. Last call in a turn wins
+			// (full-list replace), which the caller relies on.
+			if item.Name == "TodoWrite" {
+				content.Plan = ExtractPlan(item.Input)
+			}
 
 		case ContentTypeToolResult:
 			resultText := ""
@@ -590,6 +615,50 @@ func ExtractFilePathFromInput(input map[string]interface{}) string {
 		return desc
 	}
 	return ""
+}
+
+// ExtractPlan reads a TodoWrite tool input and returns its entries as ordered
+// PlanItems. It pulls each item's text from `content` (falling back to
+// `activeForm`, `task`, then `title`) and normalizes an unknown/empty status to
+// pending. Items with no text are skipped. Returns nil if the input has no
+// `todos` array (i.e. not a TodoWrite input).
+func ExtractPlan(input map[string]interface{}) []PlanItem {
+	if input == nil {
+		return nil
+	}
+	raw, ok := input["todos"].([]interface{})
+	if !ok {
+		return nil
+	}
+	var items []PlanItem
+	for _, entry := range raw {
+		m, ok := entry.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		text := firstString(m, "content", "activeForm", "task", "title")
+		if text == "" {
+			continue
+		}
+		items = append(items, PlanItem{
+			Content: text,
+			Status:  normalizePlanStatus(firstString(m, "status")),
+		})
+	}
+	return items
+}
+
+// normalizePlanStatus maps a raw status string to a known PlanItemStatus,
+// defaulting unknown/empty values to pending.
+func normalizePlanStatus(s string) PlanItemStatus {
+	switch PlanItemStatus(s) {
+	case PlanInProgress:
+		return PlanInProgress
+	case PlanCompleted:
+		return PlanCompleted
+	default:
+		return PlanPending
+	}
 }
 
 // ExtractTaskReference scans text for references to IMPLEMENTATION_PLAN.md tasks

--- a/internal/prompt/assets/spec_template.md
+++ b/internal/prompt/assets/spec_template.md
@@ -1,0 +1,13 @@
+# Ultimate Goal
+
+<Describe the goal we want to achieve, keep it short and concise.>
+
+# Acceptance Criteria
+
+Specific states that need to be achieved to call the implementation successful. List them as markdown bullet points:
+
+- A user can register, log in, and see their dashboard.
+- An admin can create, edit, and delete customer records (CRM).
+- A customer can browse a product catalog, add items to a cart, and check out (e-commerce).
+- Orders are persisted and visible in the customer's order history.
+- All listed flows are covered by passing automated tests.

--- a/internal/prompt/prompt.go
+++ b/internal/prompt/prompt.go
@@ -9,13 +9,14 @@ import (
 	"strings"
 )
 
-//go:embed assets/prompt.md assets/plan_prompt.md assets/autoresearch_prompt.md assets/autoresearch_template.md
+//go:embed assets/prompt.md assets/plan_prompt.md assets/autoresearch_prompt.md assets/autoresearch_template.md assets/spec_template.md
 var embeddedFS embed.FS
 
 const embeddedPromptPath = "assets/prompt.md"
 const embeddedPlanPromptPath = "assets/plan_prompt.md"
 const embeddedAutoresearchPromptPath = "assets/autoresearch_prompt.md"
 const embeddedAutoresearchTemplatePath = "assets/autoresearch_template.md"
+const embeddedSpecTemplatePath = "assets/spec_template.md"
 
 const defaultPlanFile = "IMPLEMENTATION_PLAN.md"
 
@@ -193,6 +194,17 @@ func GetEmbeddedAutoresearchTemplate() (string, error) {
 	content, err := embeddedFS.ReadFile(embeddedAutoresearchTemplatePath)
 	if err != nil {
 		return "", fmt.Errorf("failed to read embedded autoresearch template: %w", err)
+	}
+	return string(content), nil
+}
+
+// GetEmbeddedSpecTemplate returns the embedded spec template content.
+// It is written to specs/spec_template.md for bare `ralph` (build mode) when
+// the spec folder is empty or missing, mirroring the autoresearch template flow.
+func GetEmbeddedSpecTemplate() (string, error) {
+	content, err := embeddedFS.ReadFile(embeddedSpecTemplatePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read embedded spec template: %w", err)
 	}
 	return string(content), nil
 }

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -88,6 +88,14 @@ type Message struct {
 	Elapsed   time.Duration // wall-clock duration once the tool completed/failed
 }
 
+// PlanItem mirrors parser.PlanItem with plain-string status so the tui package
+// stays free of a parser import (matching how Message.Kind/Status are kept as
+// plain strings). It is one entry of the agent's TodoWrite-authored plan.
+type PlanItem struct {
+	Content string
+	Status  string // "pending" | "in_progress" | "completed"
+}
+
 // spinnerFrames animates in_progress tool rows, advanced once per tick.
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
@@ -221,6 +229,7 @@ type Model struct {
 	currentTask    string // Current task (e.g., "#6 Change the lib/gold into lib/silver")
 	completedTasks int    // Number of completed tasks from plan
 	totalTasks     int    // Total number of tasks from plan
+	plan           []PlanItem // Agent's TodoWrite-authored plan (ACP plan panel)
 	currentMode    string // Current mode display ("Planning", "Building", or "")
 	startTime      time.Time
 	baseElapsed    time.Duration // elapsed time from previous sessions
@@ -387,6 +396,11 @@ type toolStatusUpdateMsg struct {
 // modeUpdateMsg is sent to update the current mode display
 type modeUpdateMsg struct {
 	mode string
+}
+
+// planUpdateMsg replaces the agent's plan (a full-list TodoWrite snapshot).
+type planUpdateMsg struct {
+	items []PlanItem
 }
 
 // completedTasksUpdateMsg is sent to update the completed/total task counts
@@ -645,6 +659,31 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.currentMode = msg.mode
 		return m, nil
 
+	case planUpdateMsg:
+		// Full-list replace. Derive the footer counters from the plan so the
+		// panel and footer share a single source of truth.
+		m.plan = msg.items
+		completed, current := 0, ""
+		for _, it := range msg.items {
+			switch it.Status {
+			case "completed":
+				completed++
+			case "in_progress":
+				if current == "" {
+					current = it.Content
+				}
+			}
+		}
+		m.completedTasks = completed
+		m.totalTasks = len(msg.items)
+		if current != "" {
+			m.currentTask = current
+		}
+		if m.viewportReady {
+			m.viewport.SetContent(m.renderActivityContent())
+		}
+		return m, nil
+
 	case completedTasksUpdateMsg:
 		m.completedTasks = msg.completed
 		m.totalTasks = msg.total
@@ -709,11 +748,64 @@ func (m Model) toolElapsed(msg Message) string {
 	return ""
 }
 
+// planPanelMaxItems caps how many plan entries are shown before collapsing the
+// remainder into a "…and N more" line, keeping the panel compact.
+const planPanelMaxItems = 8
+
+// renderPlanPanel renders the agent's TodoWrite plan as a compact checklist:
+// ✓ completed (green, dim), spinner/◐ in_progress (purple), ○ pending (dim).
+// Returns "" when there is no plan.
+func (m Model) renderPlanPanel() string {
+	if len(m.plan) == 0 {
+		return ""
+	}
+	dimStyle := lipgloss.NewStyle().Foreground(colorDimGray)
+	doneStyle := lipgloss.NewStyle().Foreground(colorGreen).Strikethrough(true)
+	currentStyle := lipgloss.NewStyle().Bold(true).Foreground(colorPurple)
+	headerStyle := lipgloss.NewStyle().Bold(true).Foreground(colorPurple)
+
+	completed := 0
+	for _, it := range m.plan {
+		if it.Status == "completed" {
+			completed++
+		}
+	}
+
+	var lines []string
+	lines = append(lines, headerStyle.Render(fmt.Sprintf("📋 Plan (%d/%d)", completed, len(m.plan))))
+	for i, it := range m.plan {
+		if i >= planPanelMaxItems {
+			lines = append(lines, dimStyle.Render(fmt.Sprintf("   …and %d more", len(m.plan)-planPanelMaxItems)))
+			break
+		}
+		var glyph, text string
+		switch it.Status {
+		case "completed":
+			glyph = "✓"
+			text = doneStyle.Render(it.Content)
+		case "in_progress":
+			glyph = spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
+			text = currentStyle.Render(it.Content)
+		default:
+			glyph = "○"
+			text = dimStyle.Render(it.Content)
+		}
+		lines = append(lines, fmt.Sprintf("  %s %s", glyph, text))
+	}
+	return strings.Join(lines, "\n")
+}
+
 // renderActivityContent renders the message content for the viewport
 func (m Model) renderActivityContent() string {
+	planPanel := m.renderPlanPanel()
+
 	if len(m.messages) == 0 {
 		waitStyle := lipgloss.NewStyle().Foreground(colorDimGray)
-		return waitStyle.Render("Waiting for activity...")
+		waiting := waitStyle.Render("Waiting for activity...")
+		if planPanel != "" {
+			return planPanel + "\n\n" + waiting
+		}
+		return waiting
 	}
 
 	dimStyle := lipgloss.NewStyle().Foreground(colorDimGray)
@@ -749,7 +841,11 @@ func (m Model) renderActivityContent() string {
 		lines = append(lines, dimStyle.Italic(true).Render("💭 thinking"+dots))
 	}
 
-	return strings.Join(lines, "\n")
+	content := strings.Join(lines, "\n")
+	if planPanel != "" {
+		return planPanel + "\n\n" + content
+	}
+	return content
 }
 
 // View renders the UI
@@ -1049,6 +1145,14 @@ func SendTaskUpdate(task string) tea.Cmd {
 func SendToolStatusUpdate(toolUseID, status string) tea.Cmd {
 	return func() tea.Msg {
 		return toolStatusUpdateMsg{toolUseID: toolUseID, status: status}
+	}
+}
+
+// SendPlanUpdate is a helper command to replace the agent's plan (the panel +
+// footer counters are derived from it).
+func SendPlanUpdate(items []PlanItem) tea.Cmd {
+	return func() tea.Msg {
+		return planUpdateMsg{items: items}
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -81,9 +81,26 @@ const (
 type Message struct {
 	Role      MessageRole
 	Content   string
-	ToolUseID string // correlation key for in-place status updates (RoleTool)
-	Kind      string // ACP tool kind: read/edit/execute/search/fetch/think/...
-	Status    string // ACP tool status: in_progress/completed/failed/pending
+	ToolUseID string        // correlation key for in-place status updates (RoleTool)
+	Kind      string        // ACP tool kind: read/edit/execute/search/fetch/think/...
+	Status    string        // ACP tool status: in_progress/completed/failed/pending
+	StartedAt time.Time     // when an in_progress tool row was added (TUI clock)
+	Elapsed   time.Duration // wall-clock duration once the tool completed/failed
+}
+
+// spinnerFrames animates in_progress tool rows, advanced once per tick.
+var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// formatToolDuration renders a compact elapsed time, e.g. "420ms", "1.4s",
+// "2m3s".
+func formatToolDuration(d time.Duration) string {
+	if d < time.Second {
+		return fmt.Sprintf("%dms", d.Milliseconds())
+	}
+	if d < time.Minute {
+		return fmt.Sprintf("%.1fs", d.Seconds())
+	}
+	return fmt.Sprintf("%dm%ds", int(d.Minutes()), int(d.Seconds())%60)
 }
 
 // toolStatusGlyph returns the leading lifecycle glyph for a tool row.
@@ -196,6 +213,8 @@ type Model struct {
 	completed      bool // whether the loop has finished all iterations
 	messages       []Message
 	maxMessages    int
+	spinnerFrame    int // advances each tick to animate in_progress rows
+	inProgressTools int // count of tool rows currently in_progress
 	stats          *stats.TokenStats
 	currentLoop    int
 	totalLoops     int
@@ -320,8 +339,18 @@ func (m Model) getLoopElapsed() time.Duration {
 
 // AddMessage adds a message to the activity feed
 func (m *Model) AddMessage(msg Message) {
+	if msg.Role == RoleTool && msg.Status == "in_progress" {
+		if msg.StartedAt.IsZero() {
+			msg.StartedAt = timeNow()
+		}
+		m.inProgressTools++
+	}
 	m.messages = append(m.messages, msg)
 	if len(m.messages) > m.maxMessages {
+		// Keep the in_progress counter correct if we evict a still-running row.
+		if evicted := m.messages[0]; evicted.Role == RoleTool && evicted.Status == "in_progress" && m.inProgressTools > 0 {
+			m.inProgressTools--
+		}
 		m.messages = m.messages[1:]
 	}
 }
@@ -551,6 +580,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 	case tickMsg:
+		// Advance the spinner so in_progress rows and the thinking indicator animate.
+		m.spinnerFrame++
 		// Update viewport content and schedule next tick
 		// Note: we do NOT call GotoBottom() here — that would override the user's
 		// scroll position every 250ms, making the viewport effectively unscrollable.
@@ -591,6 +622,16 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// in place. No-op if not found (e.g. row evicted by maxMessages cap).
 		for i := len(m.messages) - 1; i >= 0; i-- {
 			if m.messages[i].Role == RoleTool && m.messages[i].ToolUseID == msg.toolUseID {
+				// Only the first resolution of a running row records timing and
+				// drops the in_progress count.
+				if m.messages[i].Status == "in_progress" {
+					if m.inProgressTools > 0 {
+						m.inProgressTools--
+					}
+					if !m.messages[i].StartedAt.IsZero() {
+						m.messages[i].Elapsed = timeNow().Sub(m.messages[i].StartedAt)
+					}
+				}
 				m.messages[i].Status = msg.status
 				break
 			}
@@ -652,6 +693,22 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	return m, tea.Batch(cmds...)
 }
 
+// toolElapsed returns the formatted elapsed time for a tool row: a live
+// running time while in_progress, the final duration once resolved, or "" if
+// no start time was recorded.
+func (m Model) toolElapsed(msg Message) string {
+	if msg.StartedAt.IsZero() {
+		return ""
+	}
+	if msg.Status == "in_progress" {
+		return formatToolDuration(timeNow().Sub(msg.StartedAt))
+	}
+	if msg.Elapsed > 0 {
+		return formatToolDuration(msg.Elapsed)
+	}
+	return ""
+}
+
 // renderActivityContent renders the message content for the viewport
 func (m Model) renderActivityContent() string {
 	if len(m.messages) == 0 {
@@ -659,21 +716,37 @@ func (m Model) renderActivityContent() string {
 		return waitStyle.Render("Waiting for activity...")
 	}
 
+	dimStyle := lipgloss.NewStyle().Foreground(colorDimGray)
+
 	var lines []string
 	for _, msg := range m.messages {
 		var line string
 		if msg.Role == RoleTool && msg.Status != "" {
-			// ACP-modeled tool row: status glyph + kind icon + styled title.
-			line = fmt.Sprintf("%s %s %s",
-				toolStatusGlyph(msg.Status),
-				toolKindIcon(msg.Kind),
-				msg.GetStyle().Render(msg.Content))
+			// ACP-modeled tool row: status glyph + kind icon + styled title +
+			// dim elapsed time. in_progress rows show an animated spinner and a
+			// live-updating timer; resolved rows show their final duration.
+			glyph := toolStatusGlyph(msg.Status)
+			if msg.Status == "in_progress" {
+				glyph = spinnerFrames[m.spinnerFrame%len(spinnerFrames)]
+			}
+			line = fmt.Sprintf("%s %s %s", glyph, toolKindIcon(msg.Kind), msg.GetStyle().Render(msg.Content))
+			if dur := m.toolElapsed(msg); dur != "" {
+				line += " " + dimStyle.Render("("+dur+")")
+			}
 		} else {
 			// Format: icon + styled content
 			line = fmt.Sprintf("%s %s", msg.GetIcon(), msg.GetStyle().Render(msg.Content))
 		}
 		lines = append(lines, line)
 		lines = append(lines, "") // Add empty line between messages
+	}
+
+	// Thinking/waiting indicator: when the loop is live but nothing is
+	// executing, the model is deciding its next step. Animate dots so the
+	// gap between steps reads as active rather than stalled.
+	if m.inProgressTools == 0 && !m.completed && !m.hibernating && !m.quitting && !m.timerPaused {
+		dots := strings.Repeat(".", 1+(m.spinnerFrame%3))
+		lines = append(lines, dimStyle.Italic(true).Render("💭 thinking"+dots))
 	}
 
 	return strings.Join(lines, "\n")

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -74,10 +74,56 @@ const (
 	RoleThinking    MessageRole = "thinking"
 )
 
-// Message represents a single activity message in the feed
+// Message represents a single activity message in the feed.
+// For RoleTool messages the ACP-modeled fields (ToolUseID, Kind, Status) let
+// the row render a kind icon + lifecycle status glyph and be mutated in place
+// when the tool finishes.
 type Message struct {
-	Role    MessageRole
-	Content string
+	Role      MessageRole
+	Content   string
+	ToolUseID string // correlation key for in-place status updates (RoleTool)
+	Kind      string // ACP tool kind: read/edit/execute/search/fetch/think/...
+	Status    string // ACP tool status: in_progress/completed/failed/pending
+}
+
+// toolStatusGlyph returns the leading lifecycle glyph for a tool row.
+func toolStatusGlyph(status string) string {
+	switch status {
+	case "in_progress":
+		return "◐"
+	case "completed":
+		return "✓"
+	case "failed":
+		return "✗"
+	case "pending":
+		return "○"
+	default:
+		return " "
+	}
+}
+
+// toolKindIcon returns the icon for an ACP tool kind.
+func toolKindIcon(kind string) string {
+	switch kind {
+	case "read":
+		return "📖"
+	case "edit":
+		return "✏️"
+	case "delete":
+		return "🗑️"
+	case "move":
+		return "🔀"
+	case "search":
+		return "🔎"
+	case "execute":
+		return "⚡"
+	case "fetch":
+		return "🌐"
+	case "think":
+		return "💭"
+	default:
+		return "🔧"
+	}
 }
 
 // GetIcon returns the emoji icon for this message's role
@@ -113,7 +159,16 @@ func (m Message) GetStyle() lipgloss.Style {
 	case RoleAssistant:
 		return lipgloss.NewStyle().Bold(true).Foreground(colorBlue)
 	case RoleTool:
-		return lipgloss.NewStyle().Bold(true).Foreground(colorPurple)
+		// Color the tool row by lifecycle status: failed→red, completed→green,
+		// running/other→purple.
+		switch m.Status {
+		case "failed":
+			return lipgloss.NewStyle().Bold(true).Foreground(colorRed)
+		case "completed":
+			return lipgloss.NewStyle().Bold(true).Foreground(colorGreen)
+		default:
+			return lipgloss.NewStyle().Bold(true).Foreground(colorPurple)
+		}
 	case RoleUser:
 		return lipgloss.NewStyle().Foreground(colorDimGray)
 	case RoleSystem:
@@ -291,6 +346,13 @@ type statsUpdateMsg struct {
 // taskUpdateMsg is sent to update the current IMPLEMENTATION_PLAN.md task
 type taskUpdateMsg struct {
 	task string
+}
+
+// toolStatusUpdateMsg is sent to flip an existing tool row's lifecycle status
+// (e.g. in_progress → completed/failed) by matching its tool_use ID.
+type toolStatusUpdateMsg struct {
+	toolUseID string
+	status    string
 }
 
 // modeUpdateMsg is sent to update the current mode display
@@ -524,6 +586,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.currentTask = msg.task
 		return m, nil
 
+	case toolStatusUpdateMsg:
+		// Find the most recent tool row with this ID and update its status
+		// in place. No-op if not found (e.g. row evicted by maxMessages cap).
+		for i := len(m.messages) - 1; i >= 0; i-- {
+			if m.messages[i].Role == RoleTool && m.messages[i].ToolUseID == msg.toolUseID {
+				m.messages[i].Status = msg.status
+				break
+			}
+		}
+		if m.viewportReady {
+			m.viewport.SetContent(m.renderActivityContent())
+		}
+		return m, nil
+
 	case modeUpdateMsg:
 		m.currentMode = msg.mode
 		return m, nil
@@ -585,11 +661,17 @@ func (m Model) renderActivityContent() string {
 
 	var lines []string
 	for _, msg := range m.messages {
-		icon := msg.GetIcon()
-		style := msg.GetStyle()
-
-		// Format: icon + styled content
-		line := fmt.Sprintf("%s %s", icon, style.Render(msg.Content))
+		var line string
+		if msg.Role == RoleTool && msg.Status != "" {
+			// ACP-modeled tool row: status glyph + kind icon + styled title.
+			line = fmt.Sprintf("%s %s %s",
+				toolStatusGlyph(msg.Status),
+				toolKindIcon(msg.Kind),
+				msg.GetStyle().Render(msg.Content))
+		} else {
+			// Format: icon + styled content
+			line = fmt.Sprintf("%s %s", msg.GetIcon(), msg.GetStyle().Render(msg.Content))
+		}
 		lines = append(lines, line)
 		lines = append(lines, "") // Add empty line between messages
 	}
@@ -886,6 +968,14 @@ func SendStatsUpdate(s *stats.TokenStats) tea.Cmd {
 func SendTaskUpdate(task string) tea.Cmd {
 	return func() tea.Msg {
 		return taskUpdateMsg{task: task}
+	}
+}
+
+// SendToolStatusUpdate is a helper command to update a tool row's lifecycle
+// status (completed/failed) by its tool_use ID.
+func SendToolStatusUpdate(toolUseID, status string) tea.Cmd {
+	return func() tea.Msg {
+		return toolStatusUpdateMsg{toolUseID: toolUseID, status: status}
 	}
 }
 

--- a/tests/config_test.go
+++ b/tests/config_test.go
@@ -922,6 +922,74 @@ func TestAutoresearchNoFilenameArgDefault(t *testing.T) {
 	}
 }
 
+func TestIsBuildMode(t *testing.T) {
+	cases := []struct {
+		subcommand string
+		want       bool
+	}{
+		{"", true},
+		{"build", true},
+		{"plan", false},
+		{"plan-and-build", false},
+		{"autoresearch", false},
+	}
+	for _, tc := range cases {
+		cfg := &config.Config{Subcommand: tc.subcommand}
+		if got := cfg.IsBuildMode(); got != tc.want {
+			t.Errorf("IsBuildMode() with subcommand %q = %v, want %v", tc.subcommand, got, tc.want)
+		}
+	}
+}
+
+func TestSpecFolderEmptyOrMissing_Missing(t *testing.T) {
+	if !config.SpecFolderEmptyOrMissing("/nonexistent/path/to/specs/") {
+		t.Error("Expected true for a missing spec folder")
+	}
+}
+
+func TestSpecFolderEmptyOrMissing_Empty(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "ralph-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	if !config.SpecFolderEmptyOrMissing(tmpDir) {
+		t.Error("Expected true for an empty spec folder")
+	}
+}
+
+func TestSpecFolderEmptyOrMissing_HasFiles(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "ralph-test-*")
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	specFile := filepath.Join(tmpDir, "spec.md")
+	if err := os.WriteFile(specFile, []byte("# spec"), 0644); err != nil {
+		t.Fatalf("Failed to write spec file: %v", err)
+	}
+
+	if config.SpecFolderEmptyOrMissing(tmpDir) {
+		t.Error("Expected false for a spec folder containing files")
+	}
+}
+
+func TestSpecFolderEmptyOrMissing_IsFile(t *testing.T) {
+	// A path that exists but is not a directory returns false so that
+	// validation can surface the more specific "expected directory" error.
+	tmpFile, err := os.CreateTemp("", "ralph-spec-*.md")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+
+	if config.SpecFolderEmptyOrMissing(tmpFile.Name()) {
+		t.Error("Expected false when the spec path is a file, not a directory")
+	}
+}
+
 // Helper function
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))

--- a/tests/parser_acp_test.go
+++ b/tests/parser_acp_test.go
@@ -152,6 +152,113 @@ func TestExtractContentToolResultStatus(t *testing.T) {
 	})
 }
 
+// TestExtractPlan verifies TodoWrite inputs become ordered PlanItems.
+func TestExtractPlan(t *testing.T) {
+	input := map[string]interface{}{
+		"todos": []interface{}{
+			map[string]interface{}{"content": "Add ClassifyToolKind", "status": "completed", "activeForm": "Adding ClassifyToolKind"},
+			map[string]interface{}{"content": "Wire dispatch", "status": "in_progress", "activeForm": "Wiring dispatch"},
+			map[string]interface{}{"content": "Write tests", "status": "pending", "activeForm": "Writing tests"},
+		},
+	}
+	plan := parser.ExtractPlan(input)
+	if len(plan) != 3 {
+		t.Fatalf("Expected 3 plan items, got %d", len(plan))
+	}
+	want := []parser.PlanItem{
+		{Content: "Add ClassifyToolKind", Status: parser.PlanCompleted},
+		{Content: "Wire dispatch", Status: parser.PlanInProgress},
+		{Content: "Write tests", Status: parser.PlanPending},
+	}
+	for i, w := range want {
+		if plan[i] != w {
+			t.Errorf("plan[%d] = %+v, want %+v", i, plan[i], w)
+		}
+	}
+}
+
+// TestExtractPlanDefensive checks fallbacks, unknown status, empty-skip, non-todo.
+func TestExtractPlanDefensive(t *testing.T) {
+	t.Run("activeForm fallback when content absent", func(t *testing.T) {
+		input := map[string]interface{}{
+			"todos": []interface{}{
+				map[string]interface{}{"activeForm": "Doing the thing", "status": "in_progress"},
+			},
+		}
+		plan := parser.ExtractPlan(input)
+		if len(plan) != 1 || plan[0].Content != "Doing the thing" {
+			t.Fatalf("expected activeForm fallback, got %+v", plan)
+		}
+	})
+
+	t.Run("unknown status normalizes to pending", func(t *testing.T) {
+		input := map[string]interface{}{
+			"todos": []interface{}{
+				map[string]interface{}{"content": "Mystery", "status": "weird"},
+				map[string]interface{}{"content": "NoStatus"},
+			},
+		}
+		plan := parser.ExtractPlan(input)
+		if len(plan) != 2 {
+			t.Fatalf("expected 2 items, got %d", len(plan))
+		}
+		if plan[0].Status != parser.PlanPending || plan[1].Status != parser.PlanPending {
+			t.Errorf("expected pending normalization, got %+v", plan)
+		}
+	})
+
+	t.Run("empty-content items skipped", func(t *testing.T) {
+		input := map[string]interface{}{
+			"todos": []interface{}{
+				map[string]interface{}{"content": "", "status": "completed"},
+				map[string]interface{}{"status": "pending"},
+				map[string]interface{}{"content": "Kept", "status": "pending"},
+			},
+		}
+		plan := parser.ExtractPlan(input)
+		if len(plan) != 1 || plan[0].Content != "Kept" {
+			t.Fatalf("expected only non-empty item kept, got %+v", plan)
+		}
+	})
+
+	t.Run("non-todo input returns nil", func(t *testing.T) {
+		if plan := parser.ExtractPlan(map[string]interface{}{"file_path": "x.go"}); plan != nil {
+			t.Errorf("expected nil for non-todo input, got %+v", plan)
+		}
+		if plan := parser.ExtractPlan(nil); plan != nil {
+			t.Errorf("expected nil for nil input, got %+v", plan)
+		}
+	})
+}
+
+// TestExtractContentPopulatesPlan verifies a TodoWrite tool_use surfaces a Plan
+// on ParsedContent, and that the tool use is still counted (noop semantics).
+func TestExtractContentPopulatesPlan(t *testing.T) {
+	p := parser.NewParser()
+	line := `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_t","name":"TodoWrite","input":{"todos":[{"content":"A","status":"completed"},{"content":"B","status":"in_progress"}]}}]}}`
+	content := p.ExtractContent(p.ParseLine(line))
+	if len(content.Plan) != 2 {
+		t.Fatalf("expected 2 plan items, got %d", len(content.Plan))
+	}
+	if content.Plan[0].Status != parser.PlanCompleted || content.Plan[1].Status != parser.PlanInProgress {
+		t.Errorf("unexpected plan statuses: %+v", content.Plan)
+	}
+	// The TodoWrite tool use is still present so iterToolUseCount is unaffected.
+	if len(content.ToolUses) != 1 {
+		t.Errorf("expected TodoWrite to still appear as a tool use, got %d", len(content.ToolUses))
+	}
+}
+
+// TestExtractContentNoPlanForNonTodo verifies non-TodoWrite tools leave Plan nil.
+func TestExtractContentNoPlanForNonTodo(t *testing.T) {
+	p := parser.NewParser()
+	line := `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_r","name":"Read","input":{"file_path":"/a/b.go"}}]}}`
+	content := p.ExtractContent(p.ParseLine(line))
+	if content.Plan != nil {
+		t.Errorf("expected nil Plan for non-TodoWrite tool, got %+v", content.Plan)
+	}
+}
+
 // TestToolTitleTruncation ensures long commands/patterns are truncated.
 func TestToolTitleTruncation(t *testing.T) {
 	p := parser.NewParser()

--- a/tests/parser_acp_test.go
+++ b/tests/parser_acp_test.go
@@ -1,0 +1,167 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cloudosai/ralph-go/internal/parser"
+)
+
+// TestClassifyToolKind verifies Claude tool names map to ACP-style kinds.
+func TestClassifyToolKind(t *testing.T) {
+	cases := []struct {
+		name string
+		want parser.ToolKind
+	}{
+		{"Read", parser.ToolKindRead},
+		{"NotebookRead", parser.ToolKindRead},
+		{"Edit", parser.ToolKindEdit},
+		{"MultiEdit", parser.ToolKindEdit},
+		{"Write", parser.ToolKindEdit},
+		{"Bash", parser.ToolKindExecute},
+		{"Glob", parser.ToolKindSearch},
+		{"Grep", parser.ToolKindSearch},
+		{"WebFetch", parser.ToolKindFetch},
+		{"Task", parser.ToolKindThink},
+		{"SomeMcpTool", parser.ToolKindOther},
+		{"", parser.ToolKindOther},
+	}
+	for _, c := range cases {
+		if got := parser.ClassifyToolKind(c.name); got != c.want {
+			t.Errorf("ClassifyToolKind(%q) = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// TestExtractContentToolUseACPFields verifies ID/Kind/Title/Location are
+// populated on the extracted ToolUse.
+func TestExtractContentToolUseACPFields(t *testing.T) {
+	p := parser.NewParser()
+
+	line := `{"type":"assistant","message":{"content":[{"type":"tool_use","id":"toolu_123","name":"Read","input":{"file_path":"/proj/internal/config.go"}}]}}`
+	content := p.ExtractContent(p.ParseLine(line))
+
+	if len(content.ToolUses) != 1 {
+		t.Fatalf("Expected 1 tool use, got %d", len(content.ToolUses))
+	}
+	tu := content.ToolUses[0]
+	if tu.ID != "toolu_123" {
+		t.Errorf("ID = %q, want %q", tu.ID, "toolu_123")
+	}
+	if tu.Kind != parser.ToolKindRead {
+		t.Errorf("Kind = %q, want %q", tu.Kind, parser.ToolKindRead)
+	}
+	if tu.Title != "Read config.go" {
+		t.Errorf("Title = %q, want %q", tu.Title, "Read config.go")
+	}
+	if tu.Location != "/proj/internal/config.go" {
+		t.Errorf("Location = %q, want %q", tu.Location, "/proj/internal/config.go")
+	}
+	// FilePath retained as alias for back-compat.
+	if tu.FilePath != tu.Location {
+		t.Errorf("FilePath = %q, want alias of Location %q", tu.FilePath, tu.Location)
+	}
+}
+
+// TestExtractContentToolUseTitleVariants checks title construction per kind.
+func TestExtractContentToolUseTitleVariants(t *testing.T) {
+	p := parser.NewParser()
+	cases := []struct {
+		name      string
+		line      string
+		wantTitle string
+	}{
+		{
+			"bash with description",
+			`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"go build ./...","description":"Build the project"}}]}}`,
+			"Build the project",
+		},
+		{
+			"bash without description",
+			`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"echo hi"}}]}}`,
+			"Bash: echo hi",
+		},
+		{
+			"grep pattern",
+			`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Grep","input":{"pattern":"func main"}}]}}`,
+			"Grep func main",
+		},
+		{
+			"task description",
+			`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Task","input":{"description":"Explore the codebase"}}]}}`,
+			"Explore the codebase",
+		},
+		{
+			"unknown tool falls back to name",
+			`{"type":"assistant","message":{"content":[{"type":"tool_use","name":"WeirdTool","input":{}}]}}`,
+			"WeirdTool",
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			content := p.ExtractContent(p.ParseLine(c.line))
+			if len(content.ToolUses) != 1 {
+				t.Fatalf("Expected 1 tool use, got %d", len(content.ToolUses))
+			}
+			if got := content.ToolUses[0].Title; got != c.wantTitle {
+				t.Errorf("Title = %q, want %q", got, c.wantTitle)
+			}
+		})
+	}
+}
+
+// TestExtractContentToolResultStatus verifies tool_result carries the
+// correlating ID and error flag for status mapping.
+func TestExtractContentToolResultStatus(t *testing.T) {
+	p := parser.NewParser()
+
+	t.Run("success", func(t *testing.T) {
+		line := `{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_1","content":"ok"}]}}`
+		content := p.ExtractContent(p.ParseLine(line))
+		if len(content.ToolResults) != 1 {
+			t.Fatalf("Expected 1 tool result, got %d", len(content.ToolResults))
+		}
+		if content.ToolResults[0].ToolUseID != "toolu_1" {
+			t.Errorf("ToolUseID = %q, want %q", content.ToolResults[0].ToolUseID, "toolu_1")
+		}
+		if content.ToolResults[0].IsError {
+			t.Error("expected IsError=false for successful result")
+		}
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		line := `{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_2","is_error":true,"content":"boom"}]}}`
+		content := p.ExtractContent(p.ParseLine(line))
+		if len(content.ToolResults) != 1 {
+			t.Fatalf("Expected 1 tool result, got %d", len(content.ToolResults))
+		}
+		if !content.ToolResults[0].IsError {
+			t.Error("expected IsError=true for failed result")
+		}
+	})
+
+	t.Run("empty content still recorded when id present", func(t *testing.T) {
+		line := `{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"toolu_3","content":""}]}}`
+		content := p.ExtractContent(p.ParseLine(line))
+		if len(content.ToolResults) != 1 {
+			t.Fatalf("Expected 1 tool result (empty content but with id), got %d", len(content.ToolResults))
+		}
+		if content.ToolResults[0].ToolUseID != "toolu_3" {
+			t.Errorf("ToolUseID = %q, want %q", content.ToolResults[0].ToolUseID, "toolu_3")
+		}
+	})
+}
+
+// TestToolTitleTruncation ensures long commands/patterns are truncated.
+func TestToolTitleTruncation(t *testing.T) {
+	p := parser.NewParser()
+	longCmd := strings.Repeat("x", 200)
+	line := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"` + longCmd + `"}}]}}`
+	content := p.ExtractContent(p.ParseLine(line))
+	if len(content.ToolUses) != 1 {
+		t.Fatalf("Expected 1 tool use, got %d", len(content.ToolUses))
+	}
+	if !strings.HasSuffix(content.ToolUses[0].Title, "...") {
+		t.Errorf("expected truncated title to end with ..., got %q", content.ToolUses[0].Title)
+	}
+}

--- a/tests/prompt_test.go
+++ b/tests/prompt_test.go
@@ -496,6 +496,23 @@ func TestAutoresearchTemplateLoads(t *testing.T) {
 	}
 }
 
+func TestSpecTemplateLoads(t *testing.T) {
+	content, err := prompt.GetEmbeddedSpecTemplate()
+	if err != nil {
+		t.Fatalf("Expected no error loading spec template, got: %v", err)
+	}
+
+	if len(content) == 0 {
+		t.Error("Expected non-empty spec template content")
+	}
+	if !strings.Contains(content, "Ultimate Goal") {
+		t.Error("Expected spec template to contain 'Ultimate Goal'")
+	}
+	if !strings.Contains(content, "Acceptance Criteria") {
+		t.Error("Expected spec template to contain 'Acceptance Criteria'")
+	}
+}
+
 func TestAutoresearchPromptContainsIterationPlaceholders(t *testing.T) {
 	// The raw embedded prompt should contain $loop_iteration and $loop_total
 	// (these get substituted by the loop at runtime, not by the prompt loader)

--- a/tests/tui_acp_test.go
+++ b/tests/tui_acp_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"strings"
 	"testing"
+	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/cloudosai/ralph-go/internal/tui"
@@ -33,8 +34,8 @@ func TestToolRowRendersKindAndStatusGlyph(t *testing.T) {
 	if !strings.Contains(view, "Read config.go") {
 		t.Errorf("view missing tool title; got:\n%s", view)
 	}
-	if !strings.Contains(view, "◐") {
-		t.Errorf("view missing in_progress glyph ◐; got:\n%s", view)
+	if !strings.Contains(view, "⠋") {
+		t.Errorf("view missing in_progress spinner glyph; got:\n%s", view)
 	}
 	if !strings.Contains(view, "📖") {
 		t.Errorf("view missing read kind icon; got:\n%s", view)
@@ -87,8 +88,49 @@ func TestToolStatusUpdateOnlyMatchingRow(t *testing.T) {
 	if !strings.Contains(view, "✓") {
 		t.Errorf("expected a completed glyph for t1; got:\n%s", view)
 	}
-	if !strings.Contains(view, "◐") {
-		t.Errorf("expected t2 to remain in_progress (◐); got:\n%s", view)
+	if !strings.Contains(view, "⠋") {
+		t.Errorf("expected t2 to remain in_progress (spinner); got:\n%s", view)
+	}
+}
+
+// TestToolRowShowsDurationOnCompletion verifies elapsed time is rendered when a
+// tool resolves, using a controlled clock.
+func TestToolRowShowsDurationOnCompletion(t *testing.T) {
+	base := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	now := base
+	tui.SetTimeNowForTest(func() time.Time { return now })
+	defer tui.SetTimeNowForTest(time.Now)
+
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+	model = addToolRow(t, model, "t1", "execute", "in_progress", "Bash: go build")
+
+	// Advance the clock 1.4s, then complete the tool.
+	now = base.Add(1400 * time.Millisecond)
+	model, _ = updateModel(model, tui.SendToolStatusUpdate("t1", "completed")())
+
+	view := model.View()
+	if !strings.Contains(view, "1.4s") {
+		t.Errorf("expected completed row to show elapsed 1.4s; got:\n%s", view)
+	}
+}
+
+// TestThinkingIndicatorShownWhenIdle verifies the thinking/waiting indicator
+// appears only when no tool is in progress.
+func TestThinkingIndicatorShownWhenIdle(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+	model = addToolRow(t, model, "t1", "read", "in_progress", "Read config.go")
+
+	// While a tool is running, no thinking indicator.
+	if strings.Contains(model.View(), "thinking") {
+		t.Errorf("did not expect thinking indicator while a tool is in_progress; got:\n%s", model.View())
+	}
+
+	// After it completes, the loop is idle → thinking indicator appears.
+	model, _ = updateModel(model, tui.SendToolStatusUpdate("t1", "completed")())
+	if !strings.Contains(model.View(), "thinking") {
+		t.Errorf("expected thinking indicator once idle; got:\n%s", model.View())
 	}
 }
 
@@ -103,7 +145,7 @@ func TestToolStatusUpdateUnknownIDNoCrash(t *testing.T) {
 
 	view := model.View()
 	// t1 should still be in_progress since nothing matched.
-	if !strings.Contains(view, "◐") {
+	if !strings.Contains(view, "⠋") {
 		t.Errorf("expected t1 to remain in_progress after no-op update; got:\n%s", view)
 	}
 }

--- a/tests/tui_acp_test.go
+++ b/tests/tui_acp_test.go
@@ -1,0 +1,109 @@
+package tests
+
+import (
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/cloudosai/ralph-go/internal/tui"
+)
+
+// addToolRow pushes a RoleTool message through the normal newMessageMsg path.
+func addToolRow(t *testing.T, m tui.Model, id, kind, status, content string) tui.Model {
+	t.Helper()
+	msg := tui.SendMessage(tui.Message{
+		Role:      tui.RoleTool,
+		Content:   content,
+		ToolUseID: id,
+		Kind:      kind,
+		Status:    status,
+	})()
+	m, _ = updateModel(m, msg)
+	return m
+}
+
+// TestToolRowRendersKindAndStatusGlyph verifies an in_progress tool row shows
+// the kind icon and the in_progress glyph.
+func TestToolRowRendersKindAndStatusGlyph(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+	model = addToolRow(t, model, "t1", "read", "in_progress", "Read config.go")
+
+	view := model.View()
+	if !strings.Contains(view, "Read config.go") {
+		t.Errorf("view missing tool title; got:\n%s", view)
+	}
+	if !strings.Contains(view, "◐") {
+		t.Errorf("view missing in_progress glyph ◐; got:\n%s", view)
+	}
+	if !strings.Contains(view, "📖") {
+		t.Errorf("view missing read kind icon; got:\n%s", view)
+	}
+}
+
+// TestToolStatusUpdateCompletes verifies a completed update flips the glyph.
+func TestToolStatusUpdateCompletes(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+	model = addToolRow(t, model, "t1", "read", "in_progress", "Read config.go")
+
+	// Flip to completed via the exported helper command.
+	doneMsg := tui.SendToolStatusUpdate("t1", "completed")()
+	model, _ = updateModel(model, doneMsg)
+
+	view := model.View()
+	if !strings.Contains(view, "✓") {
+		t.Errorf("view missing completed glyph ✓ after status update; got:\n%s", view)
+	}
+}
+
+// TestToolStatusUpdateFails verifies a failed update renders the failure glyph.
+func TestToolStatusUpdateFails(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+	model = addToolRow(t, model, "t1", "execute", "in_progress", "Bash: go build")
+
+	failMsg := tui.SendToolStatusUpdate("t1", "failed")()
+	model, _ = updateModel(model, failMsg)
+
+	view := model.View()
+	if !strings.Contains(view, "✗") {
+		t.Errorf("view missing failed glyph ✗ after status update; got:\n%s", view)
+	}
+}
+
+// TestToolStatusUpdateOnlyMatchingRow verifies a status update mutates only the
+// row whose ToolUseID matches and leaves siblings untouched.
+func TestToolStatusUpdateOnlyMatchingRow(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+	model = addToolRow(t, model, "t1", "read", "in_progress", "Read alpha.go")
+	model = addToolRow(t, model, "t2", "edit", "in_progress", "Edit beta.go")
+
+	// Complete only t1.
+	model, _ = updateModel(model, tui.SendToolStatusUpdate("t1", "completed")())
+
+	view := model.View()
+	if !strings.Contains(view, "✓") {
+		t.Errorf("expected a completed glyph for t1; got:\n%s", view)
+	}
+	if !strings.Contains(view, "◐") {
+		t.Errorf("expected t2 to remain in_progress (◐); got:\n%s", view)
+	}
+}
+
+// TestToolStatusUpdateUnknownIDNoCrash verifies an update for an unknown ID is a
+// harmless no-op.
+func TestToolStatusUpdateUnknownIDNoCrash(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+	model = addToolRow(t, model, "t1", "read", "in_progress", "Read config.go")
+
+	model, _ = updateModel(model, tui.SendToolStatusUpdate("does-not-exist", "completed")())
+
+	view := model.View()
+	// t1 should still be in_progress since nothing matched.
+	if !strings.Contains(view, "◐") {
+		t.Errorf("expected t1 to remain in_progress after no-op update; got:\n%s", view)
+	}
+}

--- a/tests/tui_acp_test.go
+++ b/tests/tui_acp_test.go
@@ -149,3 +149,72 @@ func TestToolStatusUpdateUnknownIDNoCrash(t *testing.T) {
 		t.Errorf("expected t1 to remain in_progress after no-op update; got:\n%s", view)
 	}
 }
+
+// TestPlanUpdateDrivesFooterCounters verifies a plan update sets the footer
+// completed/total counters and the current task to the in_progress item.
+func TestPlanUpdateDrivesFooterCounters(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	plan := []tui.PlanItem{
+		{Content: "Add ClassifyToolKind", Status: "completed"},
+		{Content: "Wire dispatch", Status: "in_progress"},
+		{Content: "Write tests", Status: "pending"},
+	}
+	model, _ = updateModel(model, tui.SendPlanUpdate(plan)())
+
+	view := model.View()
+	if !strings.Contains(view, "1/3") {
+		t.Errorf("expected footer to show 1/3 completed tasks; got:\n%s", view)
+	}
+	if !strings.Contains(view, "Wire dispatch") {
+		t.Errorf("expected current task to be the in_progress item; got:\n%s", view)
+	}
+}
+
+// TestPlanPanelRendersGlyphs verifies the plan panel renders a line per item
+// with the right glyph per status.
+func TestPlanPanelRendersGlyphs(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	plan := []tui.PlanItem{
+		{Content: "Done item", Status: "completed"},
+		{Content: "Current item", Status: "in_progress"},
+		{Content: "Pending item", Status: "pending"},
+	}
+	model, _ = updateModel(model, tui.SendPlanUpdate(plan)())
+
+	view := model.View()
+	for _, want := range []string{"📋 Plan", "Done item", "Current item", "Pending item", "✓", "⠋", "○"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("expected plan panel to contain %q; got:\n%s", want, view)
+		}
+	}
+}
+
+// TestPlanUpdateReplacesNotAppends verifies a second plan update replaces the
+// previous list rather than appending to it.
+func TestPlanUpdateReplacesNotAppends(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	model, _ = updateModel(model, tui.SendPlanUpdate([]tui.PlanItem{
+		{Content: "First only", Status: "in_progress"},
+	})())
+	model, _ = updateModel(model, tui.SendPlanUpdate([]tui.PlanItem{
+		{Content: "Second A", Status: "completed"},
+		{Content: "Second B", Status: "in_progress"},
+	})())
+
+	view := model.View()
+	if strings.Contains(view, "First only") {
+		t.Errorf("expected first plan to be replaced; got:\n%s", view)
+	}
+	if !strings.Contains(view, "Second A") || !strings.Contains(view, "Second B") {
+		t.Errorf("expected second plan items present; got:\n%s", view)
+	}
+	if !strings.Contains(view, "1/2") {
+		t.Errorf("expected footer 1/2 after replace; got:\n%s", view)
+	}
+}


### PR DESCRIPTION
## Summary

Brings ACP (Agent Client Protocol) modeling to Ralph's TUI so the activity feed reads as lifecycle-aware steps and the agent's own todo list drives a live completion meter — replacing the prior generic tool rows and prose-regex task heuristic.

### Tool-step visualization (`73db548`, `f7982cb`)
- Parser gains an ACP-style `ToolKind`/`ToolStatus` model (`ClassifyToolKind`, `ToolUse{ID,Kind,Title,Location}`), correlating `tool_use` → `tool_result` by ID.
- TUI renders each tool as a lifecycle row: kind icon + status glyph + title, with an **animated spinner** for in-progress rows, **per-step duration**, and a **`💭 thinking` indicator** while the loop is live but idle between steps.

### TodoWrite → plan / completion panel (`56db73d`)
- Synthesizes an ACP `plan` from the agent's `TodoWrite` tool inputs (defensive field/status parsing; full-list-replace semantics).
- Renders a sticky plan panel at the top of the activity viewport (`✓` done / spinner current / `○` pending, capped with "…and N more") and derives the footer **completed/total + current-task** counters from the plan as the single source of truth.
- Suppresses the redundant `TodoWrite` lifecycle row (it still counts toward no-op exit detection). CLI mode prints a `[plan] N/total done` line.

### Also on this branch (not step-visualization — flagging for review)
- `058f236` — bare `ralph` writes `specs/spec_template.md` when `specs/` is empty.
- `a290b82` — gitignore Ralph runtime artifacts (`.ralph.log`, `*.claude_stats`).

## Test plan
- `go build -o ralph ./cmd/ralph`
- `go test ./tests/ ./cmd/ralph/` — all green (parser plan parsing/defensive cases, plan-panel + footer rendering, full-list replace, plus existing ACP tool-step tests).
- Visual: run a multi-step task that triggers `TodoWrite`; confirm the plan panel + footer `N/total` update live and the in_progress item is highlighted.

## Known limitation (follow-up)
In-progress tool rows resolve only reactively on a matching `tool_result`; there is no boundary reconciliation, so a row can stay spinning if its result is never parsed (iteration aborted mid-tool, truncated NDJSON line, missing `tool_use_id`). A self-healing sweep at loop/done boundaries is a candidate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)