### PR TITLE
fix: prevent a tmux-wrapped run from tearing down its own session

### DIFF
--- a/cmd/ralph/main_test.go
+++ b/cmd/ralph/main_test.go
@@ -518,15 +518,48 @@ func TestHandleParsedMessageCLI_AuthError_StopsLoop(t *testing.T) {
 }
 
 func TestDefaultCommandBuilder_InheritsEnvironment(t *testing.T) {
-	// When ANTHROPIC_API_KEY is set in the parent process, the subprocess
-	// should inherit it. Go's exec.Cmd inherits the full parent environment
-	// when Cmd.Env is nil, so we verify that DefaultCommandBuilder does NOT
-	// set Cmd.Env (which would filter the environment).
+	// The subprocess must still inherit the parent environment (e.g.
+	// ANTHROPIC_API_KEY) — but with ralph's own tmux session detached, so the
+	// child can't operate on the tmux server keeping ralph alive. Cmd.Env is
+	// therefore explicitly set to a filtered copy of the parent environment.
+	t.Setenv("ANTHROPIC_API_KEY", "sk-test-key")
 	ctx := context.Background()
 	cmd := loop.DefaultCommandBuilder(ctx, "test prompt")
 
-	if cmd.Env != nil {
-		t.Error("expected Cmd.Env to be nil (inherit parent environment), but it was explicitly set")
+	if cmd.Env == nil {
+		t.Fatal("expected Cmd.Env to be set (filtered copy of parent environment), but it was nil")
+	}
+
+	var sawKey, sawTmux bool
+	for _, kv := range cmd.Env {
+		if kv == "ANTHROPIC_API_KEY=sk-test-key" {
+			sawKey = true
+		}
+		if strings.HasPrefix(kv, "TMUX=") || strings.HasPrefix(kv, "TMUX_PANE=") {
+			sawTmux = true
+		}
+	}
+	if !sawKey {
+		t.Error("expected child env to inherit ANTHROPIC_API_KEY from the parent")
+	}
+	if sawTmux {
+		t.Error("expected TMUX/TMUX_PANE to be stripped from the child env (tmux-session isolation)")
+	}
+}
+
+func TestDefaultCommandBuilder_StripsInheritedTmux(t *testing.T) {
+	// Simulate ralph running inside its own tmux session: the child must not
+	// inherit the live TMUX handle, otherwise its tmux commands would target
+	// ralph's own server and could tear down the session ralph runs in.
+	t.Setenv("TMUX", "/private/tmp/tmux-501/default,12345,0")
+	t.Setenv("TMUX_PANE", "%0")
+	ctx := context.Background()
+	cmd := loop.DefaultCommandBuilder(ctx, "test prompt")
+
+	for _, kv := range cmd.Env {
+		if strings.HasPrefix(kv, "TMUX=") || strings.HasPrefix(kv, "TMUX_PANE=") {
+			t.Errorf("expected inherited tmux var to be stripped, found: %q", kv)
+		}
 	}
 }
 

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -19,12 +21,52 @@ type CommandBuilder func(ctx context.Context, prompt string) *exec.Cmd
 
 // DefaultCommandBuilder creates the standard claude CLI command.
 func DefaultCommandBuilder(ctx context.Context, prompt string) *exec.Cmd {
-	return exec.CommandContext(ctx, "claude",
+	cmd := exec.CommandContext(ctx, "claude",
 		"--print",
 		"--output-format", "stream-json",
 		"--dangerously-skip-permissions",
 		"--verbose",
 	)
+	cmd.Env = isolatedTmuxEnv()
+	return cmd
+}
+
+// isolatedTmuxEnv returns a copy of the current environment with the inherited
+// tmux session detached from the child claude process.
+//
+// Ralph wraps itself in a tmux session (see internal/tmux.Wrap), which exports
+// TMUX/TMUX_PANE into every descendant — including the claude CLI and anything
+// it spawns. Without isolation, a child's `tmux` commands bind to *ralph's own*
+// server and session: a nested `tmux new-session` lands on ralph's server, and
+// any server-fatal operation there (a stray `kill-server`, control-mode client
+// churn, or an Electron app's tmux-backed test suite) tears down the session
+// ralph itself runs in — killing ralph with no error and no completion marker.
+//
+// To prevent that we (1) drop TMUX/TMUX_PANE so the child no longer attaches to
+// ralph's client, and (2) point TMUX_TMPDIR at a dedicated directory so any tmux
+// server the child starts lives on its own socket, fully separate from ralph's
+// default-socket session. The agent's tmux still works normally; it just can't
+// reach the session keeping ralph alive.
+func isolatedTmuxEnv() []string {
+	src := os.Environ()
+	out := make([]string, 0, len(src)+1)
+	for _, kv := range src {
+		switch {
+		case strings.HasPrefix(kv, "TMUX="),
+			strings.HasPrefix(kv, "TMUX_PANE="),
+			strings.HasPrefix(kv, "TMUX_TMPDIR="):
+			continue
+		}
+		out = append(out, kv)
+	}
+	// Best-effort: give the child its own tmux socket directory. If we can't
+	// create it, fall back to leaving TMUX_TMPDIR unset (still isolated from
+	// ralph's client by the dropped TMUX handle above).
+	dir := filepath.Join(os.TempDir(), "ralph-agent-tmux")
+	if err := os.MkdirAll(dir, 0o700); err == nil {
+		out = append(out, "TMUX_TMPDIR="+dir)
+	}
+	return out
 }
 
 // Config holds the loop execution configuration.


### PR DESCRIPTION
## Problem

When the runner wraps itself in tmux, it exported the active tmux environment into the child process and everything that process spawned. The child's tmux commands could then target the runner's **own** tmux server:

- a nested session lands on that server, and
- any server-fatal tmux operation in child work can tear down the very session the runner lives in.

When that happens, the run dies with **no error and no completion marker** — the log simply stops mid-iteration and no stats row is written, because the process was killed externally rather than exiting on its own. This was reproduced directly: a nested tmux session created with the tmux environment inherited lands on the same server as the wrapping session, and a server-fatal operation there takes the whole run down with it.

## Fix

The child process now runs with:

- the inherited tmux session **detached** (so it no longer attaches to the runner's client), and
- its **own tmux socket directory** (so any tmux server it starts is fully separate from the runner's session).

Detaching alone is insufficient — without a separate socket directory the child's tmux would still default to the same socket as the runner's session. The rest of the environment is preserved.

## Tests

- Updated the environment-inheritance test to assert ordinary environment passes through while the tmux session variables are stripped.
- Added a test covering the strip behavior when a live tmux session is inherited.
- Build, vet, and the full suite pass.