### PR TITLE
Split TUI activity pane 2:1 (thinking | tool-use) + lockless stats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,7 @@
 
 ## Build & Test
 - Build: `go build -o ralph ./cmd/ralph`
+- Vet: `go vet ./...` (must be clean)
 - Test all: `go test -v ./tests/ ./cmd/ralph/`
 - Test single: `go test -v -run TestName ./tests/`
 - Test main: `go test -v ./cmd/ralph/`

--- a/cmd/ralph/main.go
+++ b/cmd/ralph/main.go
@@ -770,6 +770,7 @@ func handleParsedMessage(
 			)
 			// Estimate cost from token counts and update in real-time
 			estimate := stats.EstimateCostFromTokens(
+				jsonParser.GetModel(parsed),
 				usage.InputTokens,
 				usage.OutputTokens,
 				usage.CacheCreationInputTokens,
@@ -1005,6 +1006,7 @@ func handleParsedMessageCLI(
 			)
 			// Estimate cost from token counts and update in real-time
 			estimate := stats.EstimateCostFromTokens(
+				jsonParser.GetModel(parsed),
 				usage.InputTokens,
 				usage.OutputTokens,
 				usage.CacheCreationInputTokens,

--- a/cmd/ralph/main.go
+++ b/cmd/ralph/main.go
@@ -62,9 +62,9 @@ type loopTracker struct {
 	currentLoopID   string
 	loopStartTime   time.Time
 	loopStartCost   float64
-	loopStartSnap   stats.TokenStats
+	loopStartSnap   stats.Snapshot
 	lastFlushedCost float64
-	lastFlushedSnap stats.TokenStats
+	lastFlushedSnap stats.Snapshot
 }
 
 // expandDBPath returns the full path to the stats database (~/.ralph/ralph.db).

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -186,6 +186,7 @@ type ContentItem struct {
 // InnerMessage represents the message field within an assistant/user message
 type InnerMessage struct {
 	ID      string        `json:"id,omitempty"`
+	Model   string        `json:"model,omitempty"`
 	Content []ContentItem `json:"content"`
 	Usage   *Usage        `json:"usage,omitempty"`
 }
@@ -447,6 +448,15 @@ func (p *Parser) GetUsage(msg *ParsedMessage) *Usage {
 		return nil
 	}
 	return msg.Message.Usage
+}
+
+// GetModel returns the model identifier from a message (e.g. "claude-opus-4-8"),
+// or empty string if not present.
+func (p *Parser) GetModel(msg *ParsedMessage) string {
+	if msg == nil || msg.Message == nil {
+		return ""
+	}
+	return msg.Message.Model
 }
 
 // GetCost extracts the total cost from a result message

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -15,31 +15,31 @@ import (
 	_ "modernc.org/sqlite"
 )
 
+// tokenCounters is the single canonical list of token/cost counters. It is
+// embedded by both the lock-guarded TokenStats and the lock-free Snapshot, so a
+// new counter added here automatically flows to every snapshot consumer instead
+// of having to be repeated across three separate field lists.
+type tokenCounters struct {
+	InputTokens         int64   `json:"input_tokens"`
+	OutputTokens        int64   `json:"output_tokens"`
+	CacheCreationTokens int64   `json:"cache_creation_tokens"`
+	CacheReadTokens     int64   `json:"cache_read_tokens"`
+	TotalCostUSD        float64 `json:"total_cost"`
+	TotalTokensCount    int64   `json:"total_tokens"`
+	TotalElapsedNs      int64   `json:"elapsed_ns"`
+}
+
 // TokenStats tracks token usage and costs.
 // All mutating methods are protected by a sync.RWMutex for concurrent access
 // from the processLoopOutput goroutine (writer) and the BubbleTea TUI goroutine (reader).
 type TokenStats struct {
-	mu                  sync.RWMutex `json:"-"`
-	InputTokens         int64        `json:"input_tokens"`
-	OutputTokens        int64        `json:"output_tokens"`
-	CacheCreationTokens int64        `json:"cache_creation_tokens"`
-	CacheReadTokens     int64        `json:"cache_read_tokens"`
-	TotalCostUSD        float64      `json:"total_cost"`
-	TotalTokensCount    int64        `json:"total_tokens"`
-	TotalElapsedNs      int64        `json:"elapsed_ns"`
+	mu sync.RWMutex `json:"-"`
+	tokenCounters
 }
 
 // NewTokenStats creates a new empty TokenStats instance
 func NewTokenStats() *TokenStats {
-	return &TokenStats{
-		InputTokens:         0,
-		OutputTokens:        0,
-		CacheCreationTokens: 0,
-		CacheReadTokens:     0,
-		TotalCostUSD:        0.0,
-		TotalTokensCount:    0,
-		TotalElapsedNs:      0,
-	}
+	return &TokenStats{}
 }
 
 // AddUsage adds token usage counts to the stats
@@ -148,13 +148,7 @@ func (t *TokenStats) SetTotalElapsedNs(ns int64) {
 // store it in a struct field, pass it by value, or hand it to a fmt verb —
 // without copying a lock (which go vet's copylocks check forbids).
 type Snapshot struct {
-	InputTokens         int64
-	OutputTokens        int64
-	CacheCreationTokens int64
-	CacheReadTokens     int64
-	TotalCostUSD        float64
-	TotalTokensCount    int64
-	TotalElapsedNs      int64
+	tokenCounters
 }
 
 // Snapshot returns a consistent point-in-time copy of the stats for reading
@@ -162,15 +156,9 @@ type Snapshot struct {
 func (t *TokenStats) Snapshot() Snapshot {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	return Snapshot{
-		InputTokens:         t.InputTokens,
-		OutputTokens:        t.OutputTokens,
-		CacheCreationTokens: t.CacheCreationTokens,
-		CacheReadTokens:     t.CacheReadTokens,
-		TotalCostUSD:        t.TotalCostUSD,
-		TotalTokensCount:    t.InputTokens + t.OutputTokens + t.CacheCreationTokens + t.CacheReadTokens,
-		TotalElapsedNs:      t.TotalElapsedNs,
-	}
+	c := t.tokenCounters
+	c.TotalTokensCount = c.InputTokens + c.OutputTokens + c.CacheCreationTokens + c.CacheReadTokens
+	return Snapshot{tokenCounters: c}
 }
 
 // FormatTokens formats a token count into a human-readable string

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -65,9 +65,12 @@ type ModelPricing struct {
 	CacheRead     float64
 }
 
-// Per-token price sets by model tier (list prices, USD per token). Point releases
-// within a tier share pricing (every Opus 4.x is $5/$25, every Sonnet 4.x is
-// $3/$15), so PricingForModel matches tiers by substring rather than exact ID.
+// Per-token price sets by model tier (list prices, USD per token) for the
+// current model generation: Opus 4.5+ at $5/$25, Sonnet 4.x at $3/$15.
+// PricingForModel matches by tier substring rather than exact ID so new point
+// releases within a tier need no code change. Older Opus (4.0/4.1, listed at
+// $15/$75) would be under-estimated, but those aren't current-gen and any
+// estimate reconciles to the CLI's actual cost once a result arrives.
 var (
 	pricingOpus   = ModelPricing{5.00 / 1_000_000, 25.00 / 1_000_000, 6.25 / 1_000_000, 0.50 / 1_000_000}
 	pricingSonnet = ModelPricing{3.00 / 1_000_000, 15.00 / 1_000_000, 3.75 / 1_000_000, 0.30 / 1_000_000}

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -99,12 +99,26 @@ func (t *TokenStats) SetTotalElapsedNs(ns int64) {
 	t.TotalElapsedNs = ns
 }
 
-// Snapshot returns a consistent point-in-time copy of the stats for reading.
-// The returned value has a fresh (zero) mutex and can be read without locking.
-func (t *TokenStats) Snapshot() TokenStats {
+// Snapshot is an immutable, lock-free point-in-time copy of a TokenStats's
+// counters. It deliberately carries no mutex, so callers may copy it freely —
+// store it in a struct field, pass it by value, or hand it to a fmt verb —
+// without copying a lock (which go vet's copylocks check forbids).
+type Snapshot struct {
+	InputTokens         int64
+	OutputTokens        int64
+	CacheCreationTokens int64
+	CacheReadTokens     int64
+	TotalCostUSD        float64
+	TotalTokensCount    int64
+	TotalElapsedNs      int64
+}
+
+// Snapshot returns a consistent point-in-time copy of the stats for reading
+// without holding the lock.
+func (t *TokenStats) Snapshot() Snapshot {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
-	return TokenStats{
+	return Snapshot{
 		InputTokens:         t.InputTokens,
 		OutputTokens:        t.OutputTokens,
 		CacheCreationTokens: t.CacheCreationTokens,

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -53,20 +53,61 @@ func (t *TokenStats) AddUsage(input, output, cacheCreation, cacheRead int64) {
 	t.TotalTokensCount = t.InputTokens + t.OutputTokens + t.CacheCreationTokens + t.CacheReadTokens
 }
 
-// Pricing constants for Claude Sonnet 4 (per token)
-const (
-	PriceInputPerToken         = 3.00 / 1_000_000
-	PriceOutputPerToken        = 15.00 / 1_000_000
-	PriceCacheCreationPerToken = 3.75 / 1_000_000
-	PriceCacheReadPerToken     = 0.30 / 1_000_000
+// ModelPricing holds per-token USD list prices for a Claude model tier.
+// CacheCreation uses the 5-minute cache-write rate (1.25x input); CacheRead is
+// the cache-read rate (0.1x input). The Claude CLI usage stream reports a single
+// cache_creation_input_tokens figure with no TTL breakdown, so the 5-minute rate
+// is used for the estimate (matching behavior from before pricing was model-aware).
+type ModelPricing struct {
+	Input         float64
+	Output        float64
+	CacheCreation float64
+	CacheRead     float64
+}
+
+// Per-token price sets by model tier (list prices, USD per token). Point releases
+// within a tier share pricing (every Opus 4.x is $5/$25, every Sonnet 4.x is
+// $3/$15), so PricingForModel matches tiers by substring rather than exact ID.
+var (
+	pricingOpus   = ModelPricing{5.00 / 1_000_000, 25.00 / 1_000_000, 6.25 / 1_000_000, 0.50 / 1_000_000}
+	pricingSonnet = ModelPricing{3.00 / 1_000_000, 15.00 / 1_000_000, 3.75 / 1_000_000, 0.30 / 1_000_000}
+	pricingHaiku  = ModelPricing{1.00 / 1_000_000, 5.00 / 1_000_000, 1.25 / 1_000_000, 0.10 / 1_000_000}
+	pricingFable  = ModelPricing{10.00 / 1_000_000, 50.00 / 1_000_000, 12.50 / 1_000_000, 1.00 / 1_000_000}
 )
 
-// EstimateCostFromTokens computes estimated cost from token counts using hardcoded pricing
-func EstimateCostFromTokens(input, output, cacheCreation, cacheRead int64) float64 {
-	return float64(input)*PriceInputPerToken +
-		float64(output)*PriceOutputPerToken +
-		float64(cacheCreation)*PriceCacheCreationPerToken +
-		float64(cacheRead)*PriceCacheReadPerToken
+// DefaultPricing is used when the model identifier is empty or unrecognized.
+// It mirrors Claude Sonnet rates, preserving the behavior from before pricing
+// was made model-aware.
+var DefaultPricing = pricingSonnet
+
+// PricingForModel returns the price set for a Claude model identifier (e.g.
+// "claude-opus-4-8"), matching by tier substring. Empty or unrecognized
+// identifiers fall back to DefaultPricing.
+func PricingForModel(model string) ModelPricing {
+	m := strings.ToLower(model)
+	switch {
+	case strings.Contains(m, "opus"):
+		return pricingOpus
+	case strings.Contains(m, "sonnet"):
+		return pricingSonnet
+	case strings.Contains(m, "haiku"):
+		return pricingHaiku
+	case strings.Contains(m, "fable"):
+		return pricingFable
+	default:
+		return DefaultPricing
+	}
+}
+
+// EstimateCostFromTokens computes estimated cost from token counts using the
+// price set for the given model. An empty or unrecognized model uses
+// DefaultPricing.
+func EstimateCostFromTokens(model string, input, output, cacheCreation, cacheRead int64) float64 {
+	p := PricingForModel(model)
+	return float64(input)*p.Input +
+		float64(output)*p.Output +
+		float64(cacheCreation)*p.CacheCreation +
+		float64(cacheRead)*p.CacheRead
 }
 
 // AddCost adds cost to the total cost

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -241,7 +241,8 @@ type Model struct {
 	loopBaseElapsed   time.Duration // per-loop elapsed from before pause within same loop
 	loopTimerPaused   bool          // whether per-loop timer is paused
 	loopPausedElapsed time.Duration // per-loop elapsed at time of pause
-	viewport          viewport.Model
+	thinkingViewport  viewport.Model // left pane (2:1): thinking/assistant narrative, word-wrapped
+	toolViewport      viewport.Model // right pane (1:1): tool-use rows + plan panel
 	activityHeight    int
 	footerHeight      int
 	msgChan           <-chan Message
@@ -488,19 +489,32 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		// Guard viewport dimensions against going below 1
-		vpWidth := max(m.width-4, 1)
+		// Split the activity area 2:1 — a wide "thinking" pane and a narrow
+		// "tool use" pane. Each box's outer width plus its rounded border (+2)
+		// sums to m.width so the row fills the terminal exactly.
+		leftStyleWidth := max((m.width-4)*2/3, 1)
+		rightStyleWidth := max((m.width-4)-leftStyleWidth, 1)
+		leftVpWidth := max(leftStyleWidth-4, 1)
+		rightVpWidth := max(rightStyleWidth-4, 1)
 		vpHeight := max(m.activityHeight-2, 1)
 
-		// Initialize or update viewport
+		// Initialize or update both viewports
 		if !m.viewportReady {
-			m.viewport = viewport.New(vpWidth, vpHeight)
-			m.viewport.SetContent(m.renderActivityContent())
-			m.viewport.GotoBottom()
+			m.thinkingViewport = viewport.New(leftVpWidth, vpHeight)
+			m.toolViewport = viewport.New(rightVpWidth, vpHeight)
 			m.viewportReady = true
+			m.thinkingViewport.SetContent(m.renderThinkingContent())
+			m.toolViewport.SetContent(m.renderToolContent())
+			m.thinkingViewport.GotoBottom()
+			m.toolViewport.GotoBottom()
 		} else {
-			m.viewport.Width = vpWidth
-			m.viewport.Height = vpHeight
+			m.thinkingViewport.Width = leftVpWidth
+			m.thinkingViewport.Height = vpHeight
+			m.toolViewport.Width = rightVpWidth
+			m.toolViewport.Height = vpHeight
+			// Re-wrap content to the new widths.
+			m.thinkingViewport.SetContent(m.renderThinkingContent())
+			m.toolViewport.SetContent(m.renderToolContent())
 		}
 		return m, nil
 
@@ -601,7 +615,11 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// scroll position every 250ms, making the viewport effectively unscrollable.
 		// GotoBottom() is only called on viewport init and when new messages arrive.
 		if m.viewportReady {
-			m.viewport.SetContent(m.renderActivityContent())
+			m.thinkingViewport.SetContent(m.renderThinkingContent())
+			m.toolViewport.SetContent(m.renderToolContent())
+			// The tool pane auto-follows the latest activity; the thinking pane
+			// preserves the user's scroll position (no GotoBottom here).
+			m.toolViewport.GotoBottom()
 		}
 		m.updateTmuxStatusBar()
 		return m, tickCmd()
@@ -609,8 +627,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case newMessageMsg:
 		m.AddMessage(Message(msg))
 		if m.viewportReady {
-			m.viewport.SetContent(m.renderActivityContent())
-			m.viewport.GotoBottom()
+			m.thinkingViewport.SetContent(m.renderThinkingContent())
+			m.toolViewport.SetContent(m.renderToolContent())
+			m.thinkingViewport.GotoBottom()
+			m.toolViewport.GotoBottom()
 		}
 		// Continue listening for more messages
 		if m.msgChan != nil {
@@ -651,7 +671,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 		}
 		if m.viewportReady {
-			m.viewport.SetContent(m.renderActivityContent())
+			m.thinkingViewport.SetContent(m.renderThinkingContent())
+			m.toolViewport.SetContent(m.renderToolContent())
+			m.toolViewport.GotoBottom()
 		}
 		return m, nil
 
@@ -680,7 +702,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.currentTask = current
 		}
 		if m.viewportReady {
-			m.viewport.SetContent(m.renderActivityContent())
+			m.thinkingViewport.SetContent(m.renderThinkingContent())
+			m.toolViewport.SetContent(m.renderToolContent())
+			m.toolViewport.GotoBottom()
 		}
 		return m, nil
 
@@ -725,8 +749,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
-	// Handle viewport scrolling
-	m.viewport, cmd = m.viewport.Update(msg)
+	// Handle viewport scrolling — scroll keys drive the thinking pane (the tool
+	// pane auto-follows the latest activity).
+	m.thinkingViewport, cmd = m.thinkingViewport.Update(msg)
 	cmds = append(cmds, cmd)
 
 	return m, tea.Batch(cmds...)
@@ -795,25 +820,68 @@ func (m Model) renderPlanPanel() string {
 	return strings.Join(lines, "\n")
 }
 
-// renderActivityContent renders the message content for the viewport
-func (m Model) renderActivityContent() string {
-	planPanel := m.renderPlanPanel()
+// renderNarrativeLine renders one non-tool message for the thinking pane as a
+// hanging-indent block: the role icon sits in a fixed gutter and the styled
+// content is word-wrapped to the remaining width, so long thinking/assistant
+// text is shown in full instead of being clipped to a single line.
+func renderNarrativeLine(msg Message, width int) string {
+	bodyWidth := max(width-3, 1)
+	body := msg.GetStyle().Width(bodyWidth).Render(msg.Content)
+	gutter := lipgloss.NewStyle().Width(3).Render(msg.GetIcon())
+	return lipgloss.JoinHorizontal(lipgloss.Top, gutter, body)
+}
 
+// renderThinkingContent renders the left (2/3) pane: the thinking/assistant
+// narrative — every non-tool message word-wrapped to the pane width — plus the
+// idle "thinking…" indicator. Tool-use rows live in the right pane instead.
+func (m Model) renderThinkingContent() string {
+	dimStyle := lipgloss.NewStyle().Foreground(colorDimGray)
+
+	// Nothing has happened yet: show the waiting placeholder (no idle dots),
+	// matching the pre-split behavior.
 	if len(m.messages) == 0 {
-		waitStyle := lipgloss.NewStyle().Foreground(colorDimGray)
-		waiting := waitStyle.Render("Waiting for activity...")
-		if planPanel != "" {
-			return planPanel + "\n\n" + waiting
-		}
-		return waiting
+		return dimStyle.Render("Waiting for activity...")
 	}
 
+	width := m.thinkingViewport.Width
+	if width < 1 {
+		width = max(m.width-4, 1)
+	}
+
+	var lines []string
+	for _, msg := range m.messages {
+		if msg.Role == RoleTool {
+			continue // tool rows render in the right pane
+		}
+		lines = append(lines, renderNarrativeLine(msg, width))
+		lines = append(lines, "") // blank line between messages
+	}
+
+	// Thinking/waiting indicator: when the loop is live but nothing is
+	// executing, the model is deciding its next step. Animate dots so the
+	// gap between steps reads as active rather than stalled.
+	if m.inProgressTools == 0 && !m.completed && !m.hibernating && !m.quitting && !m.timerPaused {
+		dots := strings.Repeat(".", 1+(m.spinnerFrame%3))
+		lines = append(lines, dimStyle.Italic(true).Render("💭 thinking"+dots))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderToolContent renders the right (1/3) pane: the agent's plan panel pinned
+// at the top followed by the tool-use rows, each rendered exactly as before the
+// split (status glyph + kind icon + title + dim elapsed time).
+func (m Model) renderToolContent() string {
+	planPanel := m.renderPlanPanel()
 	dimStyle := lipgloss.NewStyle().Foreground(colorDimGray)
 
 	var lines []string
 	for _, msg := range m.messages {
+		if msg.Role != RoleTool {
+			continue
+		}
 		var line string
-		if msg.Role == RoleTool && msg.Status != "" {
+		if msg.Status != "" {
 			// ACP-modeled tool row: status glyph + kind icon + styled title +
 			// dim elapsed time. in_progress rows show an animated spinner and a
 			// live-updating timer; resolved rows show their final duration.
@@ -826,24 +894,19 @@ func (m Model) renderActivityContent() string {
 				line += " " + dimStyle.Render("("+dur+")")
 			}
 		} else {
-			// Format: icon + styled content
+			// Status-less tool message: icon + styled content.
 			line = fmt.Sprintf("%s %s", msg.GetIcon(), msg.GetStyle().Render(msg.Content))
 		}
 		lines = append(lines, line)
-		lines = append(lines, "") // Add empty line between messages
-	}
-
-	// Thinking/waiting indicator: when the loop is live but nothing is
-	// executing, the model is deciding its next step. Animate dots so the
-	// gap between steps reads as active rather than stalled.
-	if m.inProgressTools == 0 && !m.completed && !m.hibernating && !m.quitting && !m.timerPaused {
-		dots := strings.Repeat(".", 1+(m.spinnerFrame%3))
-		lines = append(lines, dimStyle.Italic(true).Render("💭 thinking"+dots))
+		lines = append(lines, "") // blank line between rows
 	}
 
 	content := strings.Join(lines, "\n")
 	if planPanel != "" {
-		return planPanel + "\n\n" + content
+		if content != "" {
+			return planPanel + "\n\n" + content
+		}
+		return planPanel
 	}
 	return content
 }
@@ -890,13 +953,21 @@ func (m Model) renderLayout() string {
 		statusText = "STOPPED"
 	}
 
-	// Activity panel style
-	activityStyle := lipgloss.NewStyle().
+	// Split the activity area 2:1 — a wide "thinking" pane and a narrow
+	// "tool use" pane. Each box's outer width plus its rounded border (+2) sums
+	// to m.width so the joined row fills the terminal exactly.
+	leftStyleWidth := max((m.width-4)*2/3, 1)
+	rightStyleWidth := max((m.width-4)-leftStyleWidth, 1)
+
+	paneStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).
 		BorderForeground(borderColor).
 		Padding(1, 2).
-		Width(m.width - 2).
 		Height(m.activityHeight)
+
+	thinkingPane := paneStyle.Width(leftStyleWidth).Render(m.thinkingViewport.View())
+	toolPane := paneStyle.Width(rightStyleWidth).Render(m.toolViewport.View())
+	panes := lipgloss.JoinHorizontal(lipgloss.Top, thinkingPane, toolPane)
 
 	// Centered status title at top
 	statusTitle := lipgloss.NewStyle().
@@ -906,13 +977,11 @@ func (m Model) renderLayout() string {
 		Align(lipgloss.Center).
 		Render(statusText)
 
-	activityContent := activityStyle.Render(m.viewport.View())
-
-	// Add centered status title above activity panel
+	// Add centered status title above the split activity panes
 	activityPanel := lipgloss.JoinVertical(
 		lipgloss.Left,
 		statusTitle,
-		activityContent,
+		panes,
 	)
 
 	// Render footer panels

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -472,6 +472,35 @@ func waitForDone(ch <-chan struct{}) tea.Cmd {
 	}
 }
 
+// splitPaneWidths divides the activity row into a 2:1 (thinking : tool) split.
+// Each returned outer width gets a +2 rounded border when rendered, so
+// left + right + 4 == width and the joined row fills the terminal exactly. Both
+// are floored at 1 so a tiny terminal can't produce a zero/negative dimension.
+func splitPaneWidths(width int) (left, right int) {
+	left = max((width-4)*2/3, 1)
+	right = max((width-4)-left, 1)
+	return left, right
+}
+
+// refreshPanes re-renders both viewports' content. followThinking / followTool
+// control whether each pane snaps to its latest line afterward: the tool pane
+// auto-follows the latest activity, while the thinking pane only follows when a
+// new narrative message arrives so the user's scroll position is otherwise
+// preserved. No-op until the viewports have been initialized.
+func (m *Model) refreshPanes(followThinking, followTool bool) {
+	if !m.viewportReady {
+		return
+	}
+	m.thinkingViewport.SetContent(m.renderThinkingContent())
+	m.toolViewport.SetContent(m.renderToolContent())
+	if followThinking {
+		m.thinkingViewport.GotoBottom()
+	}
+	if followTool {
+		m.toolViewport.GotoBottom()
+	}
+}
+
 // Update handles messages and updates the model
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	var cmd tea.Cmd
@@ -490,10 +519,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 
 		// Split the activity area 2:1 — a wide "thinking" pane and a narrow
-		// "tool use" pane. Each box's outer width plus its rounded border (+2)
-		// sums to m.width so the row fills the terminal exactly.
-		leftStyleWidth := max((m.width-4)*2/3, 1)
-		rightStyleWidth := max((m.width-4)-leftStyleWidth, 1)
+		// "tool use" pane (see splitPaneWidths). The inner viewport width is the
+		// box width minus its rounded border (+2) and horizontal padding (+2).
+		leftStyleWidth, rightStyleWidth := splitPaneWidths(m.width)
 		leftVpWidth := max(leftStyleWidth-4, 1)
 		rightVpWidth := max(rightStyleWidth-4, 1)
 		vpHeight := max(m.activityHeight-2, 1)
@@ -503,18 +531,15 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.thinkingViewport = viewport.New(leftVpWidth, vpHeight)
 			m.toolViewport = viewport.New(rightVpWidth, vpHeight)
 			m.viewportReady = true
-			m.thinkingViewport.SetContent(m.renderThinkingContent())
-			m.toolViewport.SetContent(m.renderToolContent())
-			m.thinkingViewport.GotoBottom()
-			m.toolViewport.GotoBottom()
+			m.refreshPanes(true, true)
 		} else {
 			m.thinkingViewport.Width = leftVpWidth
 			m.thinkingViewport.Height = vpHeight
 			m.toolViewport.Width = rightVpWidth
 			m.toolViewport.Height = vpHeight
-			// Re-wrap content to the new widths.
-			m.thinkingViewport.SetContent(m.renderThinkingContent())
-			m.toolViewport.SetContent(m.renderToolContent())
+			// Re-wrap content to the new widths; keep the thinking pane's scroll
+			// position but re-pin the auto-following tool pane to the latest row.
+			m.refreshPanes(false, true)
 		}
 		return m, nil
 
@@ -614,24 +639,20 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// Note: we do NOT call GotoBottom() here — that would override the user's
 		// scroll position every 250ms, making the viewport effectively unscrollable.
 		// GotoBottom() is only called on viewport init and when new messages arrive.
-		if m.viewportReady {
-			m.thinkingViewport.SetContent(m.renderThinkingContent())
-			m.toolViewport.SetContent(m.renderToolContent())
-			// The tool pane auto-follows the latest activity; the thinking pane
-			// preserves the user's scroll position (no GotoBottom here).
-			m.toolViewport.GotoBottom()
-		}
+		// The tool pane auto-follows the latest activity; the thinking pane
+		// preserves the user's scroll position (no GotoBottom here).
+		m.refreshPanes(false, true)
 		m.updateTmuxStatusBar()
 		return m, tickCmd()
 
 	case newMessageMsg:
-		m.AddMessage(Message(msg))
-		if m.viewportReady {
-			m.thinkingViewport.SetContent(m.renderThinkingContent())
-			m.toolViewport.SetContent(m.renderToolContent())
-			m.thinkingViewport.GotoBottom()
-			m.toolViewport.GotoBottom()
-		}
+		incoming := Message(msg)
+		m.AddMessage(incoming)
+		// Only auto-follow the thinking pane when the new message is narrative
+		// (it renders there). A tool row changes only the tool pane, so snapping
+		// the thinking pane to the bottom would needlessly discard the user's
+		// scroll position every time a tool runs.
+		m.refreshPanes(incoming.Role != RoleTool, true)
 		// Continue listening for more messages
 		if m.msgChan != nil {
 			cmds = append(cmds, waitForMessage(m.msgChan))
@@ -670,11 +691,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				break
 			}
 		}
-		if m.viewportReady {
-			m.thinkingViewport.SetContent(m.renderThinkingContent())
-			m.toolViewport.SetContent(m.renderToolContent())
-			m.toolViewport.GotoBottom()
-		}
+		m.refreshPanes(false, true)
 		return m, nil
 
 	case modeUpdateMsg:
@@ -701,11 +718,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		if current != "" {
 			m.currentTask = current
 		}
-		if m.viewportReady {
-			m.thinkingViewport.SetContent(m.renderThinkingContent())
-			m.toolViewport.SetContent(m.renderToolContent())
-			m.toolViewport.GotoBottom()
-		}
+		m.refreshPanes(false, true)
 		return m, nil
 
 	case completedTasksUpdateMsg:
@@ -845,7 +858,10 @@ func (m Model) renderThinkingContent() string {
 
 	width := m.thinkingViewport.Width
 	if width < 1 {
-		width = max(m.width-4, 1)
+		// Viewport not sized yet: mirror the left-pane inner width math so the
+		// fallback wraps to the same width the pane will use, not the full row.
+		left, _ := splitPaneWidths(m.width)
+		width = max(left-4, 1)
 	}
 
 	var lines []string
@@ -863,6 +879,13 @@ func (m Model) renderThinkingContent() string {
 	if m.inProgressTools == 0 && !m.completed && !m.hibernating && !m.quitting && !m.timerPaused {
 		dots := strings.Repeat(".", 1+(m.spinnerFrame%3))
 		lines = append(lines, dimStyle.Italic(true).Render("💭 thinking"+dots))
+	}
+
+	// Every current message is a tool row (rendered in the right pane) and the
+	// idle indicator is suppressed: show the placeholder rather than leaving the
+	// pane a blank box.
+	if len(lines) == 0 {
+		return dimStyle.Render("Waiting for activity...")
 	}
 
 	return strings.Join(lines, "\n")
@@ -954,10 +977,9 @@ func (m Model) renderLayout() string {
 	}
 
 	// Split the activity area 2:1 — a wide "thinking" pane and a narrow
-	// "tool use" pane. Each box's outer width plus its rounded border (+2) sums
-	// to m.width so the joined row fills the terminal exactly.
-	leftStyleWidth := max((m.width-4)*2/3, 1)
-	rightStyleWidth := max((m.width-4)-leftStyleWidth, 1)
+	// "tool use" pane (see splitPaneWidths); each box's +2 rounded border makes
+	// the joined row fill the terminal exactly.
+	leftStyleWidth, rightStyleWidth := splitPaneWidths(m.width)
 
 	paneStyle := lipgloss.NewStyle().
 		Border(lipgloss.RoundedBorder()).

--- a/tests/stats_test.go
+++ b/tests/stats_test.go
@@ -250,28 +250,79 @@ func TestTotalTokensCount_UpdatedAfterAddUsage(t *testing.T) {
 
 func TestEstimateCostFromTokens(t *testing.T) {
 	tests := []struct {
-		name                                       string
-		input, output, cacheCreation, cacheRead    int64
-		expected                                   float64
+		name                                    string
+		model                                   string
+		input, output, cacheCreation, cacheRead int64
+		expected                                float64
 	}{
-		{"1M input tokens", 1_000_000, 0, 0, 0, 3.00},
-		{"1M output tokens", 0, 1_000_000, 0, 0, 15.00},
-		{"1M cache creation tokens", 0, 0, 1_000_000, 0, 3.75},
-		{"1M cache read tokens", 0, 0, 0, 1_000_000, 0.30},
-		{"all zeros", 0, 0, 0, 0, 0.0},
-		{"mixed counts", 100_000, 50_000, 20_000, 200_000, 0.30 + 0.75 + 0.075 + 0.06},
+		// Sonnet pricing ($3 / $15 / $3.75 / $0.30 per 1M)
+		{"sonnet 1M input tokens", "claude-sonnet-4-6", 1_000_000, 0, 0, 0, 3.00},
+		{"sonnet 1M output tokens", "claude-sonnet-4-6", 0, 1_000_000, 0, 0, 15.00},
+		{"sonnet 1M cache creation tokens", "claude-sonnet-4-6", 0, 0, 1_000_000, 0, 3.75},
+		{"sonnet 1M cache read tokens", "claude-sonnet-4-6", 0, 0, 0, 1_000_000, 0.30},
+		{"sonnet mixed counts", "claude-sonnet-4-6", 100_000, 50_000, 20_000, 200_000, 0.30 + 0.75 + 0.075 + 0.06},
+		{"all zeros", "claude-opus-4-8", 0, 0, 0, 0, 0.0},
+		// Opus pricing ($5 / $25 / $6.25 / $0.50 per 1M)
+		{"opus 1M input tokens", "claude-opus-4-8", 1_000_000, 0, 0, 0, 5.00},
+		{"opus 1M output tokens", "claude-opus-4-8", 0, 1_000_000, 0, 0, 25.00},
+		{"opus 1M cache creation tokens", "claude-opus-4-8", 0, 0, 1_000_000, 0, 6.25},
+		{"opus 1M cache read tokens", "claude-opus-4-8", 0, 0, 0, 1_000_000, 0.50},
+		{"opus mixed counts", "claude-opus-4-8", 100_000, 50_000, 20_000, 200_000, 0.50 + 1.25 + 0.125 + 0.10},
+		// Haiku pricing ($1 / $5 / $1.25 / $0.10 per 1M)
+		{"haiku 1M input tokens", "claude-haiku-4-5", 1_000_000, 0, 0, 0, 1.00},
+		// Fable pricing ($10 / $50 / $12.50 / $1.00 per 1M)
+		{"fable 1M output tokens", "claude-fable-5", 0, 1_000_000, 0, 0, 50.00},
+		// Empty / unrecognized model falls back to Sonnet (DefaultPricing)
+		{"empty model defaults to sonnet", "", 1_000_000, 0, 0, 0, 3.00},
+		{"unknown model defaults to sonnet", "some-other-model", 0, 1_000_000, 0, 0, 15.00},
 	}
 
 	tolerance := 0.0000001
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := stats.EstimateCostFromTokens(tt.input, tt.output, tt.cacheCreation, tt.cacheRead)
+			result := stats.EstimateCostFromTokens(tt.model, tt.input, tt.output, tt.cacheCreation, tt.cacheRead)
 			diff := result - tt.expected
 			if diff < -tolerance || diff > tolerance {
-				t.Errorf("EstimateCostFromTokens(%d, %d, %d, %d) = %f, expected %f",
-					tt.input, tt.output, tt.cacheCreation, tt.cacheRead, result, tt.expected)
+				t.Errorf("EstimateCostFromTokens(%q, %d, %d, %d, %d) = %f, expected %f",
+					tt.model, tt.input, tt.output, tt.cacheCreation, tt.cacheRead, result, tt.expected)
 			}
 		})
+	}
+}
+
+func TestPricingForModel(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		want  stats.ModelPricing
+	}{
+		{"opus", "claude-opus-4-8", stats.PricingForModel("claude-opus-4-8")},
+		{"opus older point release", "claude-opus-4-6", stats.PricingForModel("claude-opus-4-8")},
+		{"opus dated snapshot", "claude-opus-4-5-20251101", stats.PricingForModel("claude-opus-4-8")},
+		{"opus bedrock prefix", "anthropic.claude-opus-4-8", stats.PricingForModel("claude-opus-4-8")},
+		{"opus uppercase", "Claude-OPUS-4-8", stats.PricingForModel("claude-opus-4-8")},
+		{"sonnet", "claude-sonnet-4-6", stats.PricingForModel("claude-sonnet-4-6")},
+		{"haiku", "claude-haiku-4-5", stats.PricingForModel("claude-haiku-4-5")},
+		{"fable", "claude-fable-5", stats.PricingForModel("claude-fable-5")},
+		{"empty falls back to default", "", stats.DefaultPricing},
+		{"unknown falls back to default", "gpt-4", stats.DefaultPricing},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stats.PricingForModel(tt.model)
+			if got != tt.want {
+				t.Errorf("PricingForModel(%q) = %+v, want %+v", tt.model, got, tt.want)
+			}
+		})
+	}
+
+	// Concrete rate checks so the table itself is asserted, not just self-consistency.
+	if p := stats.PricingForModel("claude-opus-4-8"); p.Input != 5.00/1_000_000 || p.Output != 25.00/1_000_000 {
+		t.Errorf("opus rates = %+v, want input 5/1M, output 25/1M", p)
+	}
+	if p := stats.DefaultPricing; p.Input != 3.00/1_000_000 || p.Output != 15.00/1_000_000 {
+		t.Errorf("default (sonnet) rates = %+v, want input 3/1M, output 15/1M", p)
 	}
 }
 
@@ -1133,6 +1184,7 @@ func replayFixture(t *testing.T, fixturePath string, dedup bool) (snap *stats.Sn
 					usage.CacheReadInputTokens,
 				)
 				estimate := stats.EstimateCostFromTokens(
+					p.GetModel(parsed),
 					usage.InputTokens,
 					usage.OutputTokens,
 					usage.CacheCreationInputTokens,

--- a/tests/stats_test.go
+++ b/tests/stats_test.go
@@ -1088,7 +1088,7 @@ func TestSubagentCostAccumResetsOnNewLoop(t *testing.T) {
 // logic mirroring handleParsedMessage, with optional message-ID deduplication.
 // Returns the final TokenStats snapshot, the expected cost from the result message,
 // and the peak TotalCostUSD seen during the replay (before reconciliation).
-func replayFixture(t *testing.T, fixturePath string, dedup bool) (snap *stats.TokenStats, expectedCost float64, peakCost float64) {
+func replayFixture(t *testing.T, fixturePath string, dedup bool) (snap *stats.Snapshot, expectedCost float64, peakCost float64) {
 	t.Helper()
 	data, err := os.ReadFile(fixturePath)
 	if err != nil {

--- a/tests/stats_test.go
+++ b/tests/stats_test.go
@@ -324,6 +324,14 @@ func TestPricingForModel(t *testing.T) {
 	if p := stats.DefaultPricing; p.Input != 3.00/1_000_000 || p.Output != 15.00/1_000_000 {
 		t.Errorf("default (sonnet) rates = %+v, want input 3/1M, output 15/1M", p)
 	}
+	if p := stats.PricingForModel("claude-haiku-4-5"); p.Input != 1.00/1_000_000 || p.Output != 5.00/1_000_000 ||
+		p.CacheCreation != 1.25/1_000_000 || p.CacheRead != 0.10/1_000_000 {
+		t.Errorf("haiku rates = %+v, want input 1/1M, output 5/1M, cacheWrite 1.25/1M, cacheRead 0.10/1M", p)
+	}
+	if p := stats.PricingForModel("claude-fable-5"); p.Input != 10.00/1_000_000 || p.Output != 50.00/1_000_000 ||
+		p.CacheCreation != 12.50/1_000_000 || p.CacheRead != 1.00/1_000_000 {
+		t.Errorf("fable rates = %+v, want input 10/1M, output 50/1M, cacheWrite 12.50/1M, cacheRead 1.00/1M", p)
+	}
 }
 
 func TestReconcileCost(t *testing.T) {

--- a/tests/tui_split_test.go
+++ b/tests/tui_split_test.go
@@ -128,6 +128,36 @@ func TestSplit_ScrollKeysDriveThinkingPane(t *testing.T) {
 	}
 }
 
+// TestSplit_ToolMessageKeepsThinkingScroll verifies that a tool row arriving
+// does NOT yank the thinking pane back to the bottom. The split's whole point is
+// that the thinking pane preserves the user's scroll position; only a new
+// narrative message should auto-follow it. (Regression: newMessageMsg used to
+// GotoBottom the thinking pane for every message, including tool rows.)
+func TestSplit_ToolMessageKeepsThinkingScroll(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 22})
+
+	for i := 0; i < 30; i++ {
+		model = sendTo(t, model, tui.Message{Role: tui.RoleThinking, Content: fmt.Sprintf("THINK_LINE_%02d", i)})
+	}
+	// Scroll up to the earliest line.
+	for i := 0; i < 12; i++ {
+		model, _ = updateModel(model, tea.KeyMsg{Type: tea.KeyPgUp})
+	}
+	if !strings.Contains(model.View(), "THINK_LINE_00") {
+		t.Fatalf("precondition: thinking pane should be scrolled to the top; got:\n%s", model.View())
+	}
+
+	// A tool row lands in the right pane — it must not disturb the left pane.
+	model = addToolRow(t, model, "t1", "read", "in_progress", "Read config.go")
+	if strings.Contains(model.View(), "THINK_LINE_29") {
+		t.Error("a tool message should not snap the thinking pane back to the bottom")
+	}
+	if !strings.Contains(model.View(), "THINK_LINE_00") {
+		t.Error("thinking pane scroll position should be preserved when a tool row arrives")
+	}
+}
+
 // TestSplit_NoWidthOverflow verifies the joined panes never exceed the terminal
 // width (which would wrap/garble the layout) across a range of sizes.
 func TestSplit_NoWidthOverflow(t *testing.T) {

--- a/tests/tui_split_test.go
+++ b/tests/tui_split_test.go
@@ -1,0 +1,147 @@
+package tests
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/cloudosai/ralph-go/internal/tui"
+)
+
+// sendTo pushes a message through the normal newMessageMsg path so the split
+// viewports are refreshed exactly as in production.
+func sendTo(t *testing.T, m tui.Model, msg tui.Message) tui.Model {
+	t.Helper()
+	updated, _ := updateModel(m, tui.SendMessage(msg)())
+	return updated
+}
+
+// lineContaining returns the first rendered line that contains sub, or "".
+func lineContaining(view, sub string) string {
+	for _, line := range strings.Split(view, "\n") {
+		if strings.Contains(line, sub) {
+			return line
+		}
+	}
+	return ""
+}
+
+// TestSplit_ThinkingWrappedToFullLength verifies the spec's core requirement:
+// a long thinking block is word-wrapped in the left pane and its ENTIRE length
+// is visible (both the first and last words appear). On the pre-split layout a
+// long single-line block was clipped horizontally by the viewport, so the tail
+// would be missing.
+func TestSplit_ThinkingWrappedToFullLength(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	// ~280 chars: comfortably wider than the ~73-col left pane, so it must wrap
+	// to several lines for the tail to be visible.
+	middle := strings.Repeat("reasoning step and more detail ", 8)
+	content := "THINK_HEAD " + middle + "THINK_TAIL_SENTINEL"
+	model = sendTo(t, model, tui.Message{Role: tui.RoleThinking, Content: content})
+
+	view := model.View()
+	if !strings.Contains(view, "THINK_HEAD") {
+		t.Errorf("thinking pane should show the start of the block; got:\n%s", view)
+	}
+	if !strings.Contains(view, "THINK_TAIL_SENTINEL") {
+		t.Errorf("thinking pane should show the ENTIRE length (tail) via word-wrap; got:\n%s", view)
+	}
+}
+
+// TestSplit_ThinkingAndToolCoexist verifies thinking narrative and tool-use rows
+// both render after the split, with the tool pane keeping its glyph/icon detail.
+func TestSplit_ThinkingAndToolCoexist(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	model = sendTo(t, model, tui.Message{Role: tui.RoleThinking, Content: "LEFT_THINKING_TEXT"})
+	model = addToolRow(t, model, "t1", "read", "in_progress", "Read config.go")
+
+	view := model.View()
+	for _, want := range []string{"LEFT_THINKING_TEXT", "Read config.go", "📖", "⠋"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("split view should contain %q; got:\n%s", want, view)
+		}
+	}
+}
+
+// TestSplit_PanesAreSideBySide verifies the panes are laid out horizontally:
+// a thinking message and a tool row added in the same turn land on the SAME
+// physical rendered line (left column then right column). This fails on the old
+// vertical single-pane layout where they would be on different lines.
+func TestSplit_PanesAreSideBySide(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	model = sendTo(t, model, tui.Message{Role: tui.RoleThinking, Content: "ALPHA_THINK"})
+	model = addToolRow(t, model, "t1", "read", "in_progress", "BETA_TOOL")
+
+	view := model.View()
+	line := lineContaining(view, "ALPHA_THINK")
+	if line == "" {
+		t.Fatalf("expected a line containing ALPHA_THINK; got:\n%s", view)
+	}
+	if !strings.Contains(line, "BETA_TOOL") {
+		t.Errorf("expected ALPHA_THINK (left pane) and BETA_TOOL (right pane) on the same physical line (side-by-side split); got line:\n%q\nfull view:\n%s", line, view)
+	}
+	// And the left content must come before the right content on that line.
+	if strings.Index(line, "ALPHA_THINK") >= strings.Index(line, "BETA_TOOL") {
+		t.Errorf("thinking pane should be left of the tool pane; got line:\n%q", line)
+	}
+}
+
+// TestSplit_ScrollKeysDriveThinkingPane verifies PgUp scrolls the left/thinking
+// pane (where the narrative lives) and a tick does not snap it back.
+func TestSplit_ScrollKeysDriveThinkingPane(t *testing.T) {
+	model := tui.NewModel()
+	// Small height so the thinking pane must scroll.
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 22})
+
+	for i := 0; i < 30; i++ {
+		model = sendTo(t, model, tui.Message{Role: tui.RoleThinking, Content: fmt.Sprintf("THINK_LINE_%02d", i)})
+	}
+
+	// Newest visible at bottom on arrival.
+	if !strings.Contains(model.View(), "THINK_LINE_29") {
+		t.Fatalf("thinking pane should auto-scroll to the newest line; got:\n%s", model.View())
+	}
+
+	for i := 0; i < 12; i++ {
+		model, _ = updateModel(model, tea.KeyMsg{Type: tea.KeyPgUp})
+	}
+	scrolled := model.View()
+	if !strings.Contains(scrolled, "THINK_LINE_00") {
+		t.Fatalf("PgUp should scroll the thinking pane to the earliest line; got:\n%s", scrolled)
+	}
+
+	// A tick must not reset the scroll position.
+	model, _ = updateModel(model, tui.TickMsgForTest())
+	if strings.Contains(model.View(), "THINK_LINE_29") {
+		t.Error("tick should not snap the thinking pane back to bottom")
+	}
+	if !strings.Contains(model.View(), "THINK_LINE_00") {
+		t.Error("thinking pane scroll position should be preserved across a tick")
+	}
+}
+
+// TestSplit_NoWidthOverflow verifies the joined panes never exceed the terminal
+// width (which would wrap/garble the layout) across a range of sizes.
+func TestSplit_NoWidthOverflow(t *testing.T) {
+	for _, w := range []int{40, 80, 120, 200} {
+		model := tui.NewModel()
+		model, _ = updateModel(model, tea.WindowSizeMsg{Width: w, Height: 40})
+		model = sendTo(t, model, tui.Message{Role: tui.RoleThinking, Content: "width check"})
+		model = addToolRow(t, model, "t1", "execute", "in_progress", "Bash: go build ./...")
+
+		view := model.View()
+		for _, line := range strings.Split(view, "\n") {
+			if lw := lipgloss.Width(line); lw > w {
+				t.Errorf("at terminal width %d a rendered line is %d wide (overflow): %q", w, lw, line)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## What

Splits the TUI activity panel into two side-by-side viewports and lands two supporting cleanups.

- **Left pane (2:1):** thinking/assistant narrative, word-wrapped so long reasoning is shown in full instead of being clipped to one line.
- **Right pane (1:1):** tool-use rows + the agent's plan panel, rendered exactly as before the split.
- **`stats.Snapshot`:** a lock-free, mutex-free point-in-time copy so snapshots can be stored/copied/passed by value without tripping `go vet`'s copylocks check. Counters now live in one shared `tokenCounters` struct embedded by both `TokenStats` and `Snapshot`.
- **Model-aware pricing:** token-cost estimates use per-tier price sets (Opus/Sonnet/Haiku/Fable), matched by tier substring, reconciling to the CLI's actual cost.

## Review follow-up (in the latest commit)

A code-review pass on the split surfaced and fixed:
- Thinking pane no longer snaps to the bottom when a **tool row** arrives (it renders in the other pane) — that was discarding the user's scroll position on every tool call. Covered by a new regression test.
- `splitPaneWidths()` is now the single source of truth for the 2:1 width math (was duplicated in the resize handler and `renderLayout`, with drift risk).
- The six `SetContent`/`GotoBottom` update sites are consolidated into `refreshPanes(...)`; the tool pane is re-pinned to the latest row after a resize.
- The left pane shows the "Waiting for activity…" placeholder instead of a blank box when every message is a tool row.

## Known follow-ups (not in this PR)

- **Scrollable tool pane:** the right pane auto-follows the latest activity and isn't keyboard-scrollable, so the plan panel scrolls off once it overflows. Fixing it well needs a focus-switch (e.g. Tab to choose which pane the scroll keys drive) — a separate change.
- **Per-tick render cost:** every 250ms tick re-word-wraps the full narrative history, including off-screen lines. Worth memoizing render output keyed on content + width.

## Test plan

- `go build ./cmd/ralph` ✅
- `go vet ./...` ✅ (clean)
- `go test ./tests/ ./cmd/ralph/` ✅, including under `-race` ✅
- New split tests: side-by-side layout, full-length word-wrap, scroll preservation across ticks and tool messages, no width overflow across terminal sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)