### PR TITLE
feat(tui): add (D)elete-plan hotkey that resets the loop

### DIFF
--- a/cmd/ralph/main.go
+++ b/cmd/ralph/main.go
@@ -421,6 +421,7 @@ func main() {
 	model.SetLoop(claudeLoop)
 	model.SetTmuxStatusBar(tmuxBar)
 	model.SetGitContext(dbCtx.repo, dbCtx.branch)
+	model.SetPlanFile(cfg.PlanFile)
 
 	// Parse implementation plan for task counts
 	completedTasks, totalTasks := parseTaskCounts(cfg.PlanFile)
@@ -1482,6 +1483,7 @@ func runPlanAndBuild(cfg *config.Config, tokenStats *stats.TokenStats, logFile i
 	model.SetLoopProgress(0, cfg.Iterations)
 	model.SetTmuxStatusBar(tmuxBar)
 	model.SetGitContext(dbCtx.repo, dbCtx.branch)
+	model.SetPlanFile(cfg.PlanFile)
 
 	// Parse implementation plan for task counts
 	completedTasks, totalTasks := parseTaskCounts(cfg.PlanFile)
@@ -1824,7 +1826,8 @@ func isNewLoopStart(content string) bool {
 		!strings.Contains(content, "STOPPED") &&
 		!strings.Contains(content, "COMPLETED") &&
 		!strings.Contains(content, "RESUMED") &&
-		!strings.Contains(content, "RETRY")
+		!strings.Contains(content, "RETRY") &&
+		!strings.Contains(content, "RESET")
 }
 
 // isRetryLoopStart returns true when the loop marker indicates a hibernate retry

--- a/cmd/ralph/main_test.go
+++ b/cmd/ralph/main_test.go
@@ -277,6 +277,7 @@ func TestHandleLoopMarkerReturnsTrue(t *testing.T) {
 		{"======= RESUMED =======", false},
 		{"======= LOOP 1/5 (RETRY) =======", false},
 		{"======= LOOP 3/5 (RETRY) =======", false},
+		{"======= LOOP RESET =======", false},
 	}
 
 	for _, tt := range tests {

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -101,6 +101,7 @@ type Loop struct {
 	hibernating      bool               // whether loop is hibernating due to rate limit
 	hibernateUntil   time.Time          // when rate limit resets
 	hibernateCh      chan struct{}      // channel to signal manual wake
+	resetRequested   bool               // whether a reset has been requested (restart from iteration 1)
 }
 
 // New creates a new Loop with the given configuration.
@@ -232,6 +233,57 @@ func (l *Loop) IsHibernating() bool {
 	return l.hibernating
 }
 
+// consumeResetRequest checks whether a reset was requested via Reset().
+// If so, it clears the flag, sends a "LOOP RESET" marker on the output channel,
+// and returns true so the caller can restart from iteration 1.
+func (l *Loop) consumeResetRequest() bool {
+	l.mu.Lock()
+	req := l.resetRequested
+	if req {
+		l.resetRequested = false
+	}
+	l.mu.Unlock()
+	if !req {
+		return false
+	}
+	total := l.GetIterations()
+	l.output <- Message{
+		Type:    "loop_marker",
+		Content: "======= LOOP RESET =======",
+		Loop:    1,
+		Total:   total,
+	}
+	return true
+}
+
+// Reset stops the current iteration and restarts the loop from iteration 1
+// with a fresh session (no --resume). Used when IMPLEMENTATION_PLAN.md is
+// deleted mid-run so the agent re-creates the plan from scratch.
+// Works whether the loop is running, paused, or completed-waiting.
+func (l *Loop) Reset() {
+	l.mu.Lock()
+	l.resetRequested = true
+	l.resumeSessionID = "" // fresh start — no --resume
+	wasPaused := l.paused
+	l.paused = false
+	cw := l.completedWaiting
+	l.mu.Unlock()
+
+	// Cancel current iteration to interrupt it immediately
+	if l.iterationCancel != nil {
+		l.iterationCancel()
+	}
+
+	// If paused or completed-waiting, wake the run goroutine so it can
+	// observe the reset flag and restart from iteration 1.
+	if wasPaused || cw {
+		select {
+		case l.resumeCh <- struct{}{}:
+		default:
+		}
+	}
+}
+
 // GetHibernateUntil returns the time when the hibernate period ends.
 func (l *Loop) GetHibernateUntil() time.Time {
 	l.mu.Lock()
@@ -337,6 +389,12 @@ func (l *Loop) run(ctx context.Context) {
 				}
 			}
 
+			// Check if a reset was requested (covers resume from first pause)
+			if l.consumeResetRequest() {
+				i = 0 // for loop will increment to 1
+				continue
+			}
+
 			// Send loop marker
 			total := l.GetIterations()
 			markerContent := fmt.Sprintf("======= LOOP %d/%d =======", i, total)
@@ -423,6 +481,12 @@ func (l *Loop) run(ctx context.Context) {
 				continue
 			}
 
+			// Check if a reset was requested (covers interrupt during execution)
+			if l.consumeResetRequest() {
+				i = 0 // for loop will increment to 1
+				continue
+			}
+
 			if err != nil {
 				total := l.GetIterations()
 				l.output <- Message{
@@ -468,6 +532,12 @@ func (l *Loop) run(ctx context.Context) {
 			l.mu.Lock()
 			l.completedWaiting = false
 			l.mu.Unlock()
+		}
+
+		// Check if a reset was requested (covers completed-waiting state)
+		if l.consumeResetRequest() {
+			i = 1 // restart from iteration 1
+			continue
 		}
 
 		// Check if new iterations were actually added

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -2,6 +2,7 @@ package tui
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
@@ -253,6 +254,8 @@ type Model struct {
 	hibernateUntil    time.Time // when rate limit resets
 	repoName          string    // git repo name for tmux status bar
 	branchName        string    // git branch name for tmux status bar
+	planFile          string    // path to the implementation plan file (for delete-and-reset)
+	confirmDeletePlan bool      // whether the delete-plan confirmation modal is open
 }
 
 // NewModel creates and returns a new initialized Model
@@ -313,6 +316,11 @@ func (m *Model) SetTmuxStatusBar(sb tmuxBarUpdater) {
 func (m *Model) SetGitContext(repo, branch string) {
 	m.repoName = repo
 	m.branchName = branch
+}
+
+// SetPlanFile sets the implementation plan file path (used by the delete-and-reset hotkey).
+func (m *Model) SetPlanFile(path string) {
+	m.planFile = path
 }
 
 // SetCompletedTasks sets the completed/total task counts from the implementation plan
@@ -544,6 +552,69 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 
 	case tea.KeyMsg:
+		// When the delete-plan confirmation modal is open, intercept y/n/q.
+		if m.confirmDeletePlan {
+			switch msg.String() {
+			case "y", "Y":
+				m.confirmDeletePlan = false
+				// Delete the plan file if it exists
+				if m.planFile != "" {
+					if _, err := os.Stat(m.planFile); err == nil {
+						os.Remove(m.planFile)
+					}
+				}
+				// Reset the loop so the agent re-creates the plan from scratch
+				if m.loop != nil {
+					m.loop.Reset()
+					// Clear completed state and task tracking
+					m.completed = false
+					m.completedTasks = 0
+					m.totalTasks = 0
+					m.currentTask = ""
+					m.plan = nil
+					// Resume timers since reset restarts execution
+					if m.timerPaused {
+						m.baseElapsed = m.pausedElapsed
+						m.startTime = timeNow()
+						m.timerPaused = false
+					}
+					if m.loopTimerPaused {
+						m.loopBaseElapsed = m.loopPausedElapsed
+						m.loopStartTime = timeNow()
+						m.loopTimerPaused = false
+					}
+				}
+				m.AddMessage(Message{
+					Role:    RoleLoop,
+					Content: "Plan deleted — loop reset to re-create IMPLEMENTATION_PLAN.md",
+				})
+				m.refreshPanes(true, true)
+				return m, nil
+			case "n", "N", "esc":
+				m.confirmDeletePlan = false
+				return m, nil
+			case "q", "ctrl+c":
+				// Allow quit even from the modal
+				if m.stats != nil {
+					var totalElapsed time.Duration
+					if m.timerPaused {
+						totalElapsed = m.pausedElapsed
+					} else {
+						totalElapsed = m.baseElapsed + timeNow().Sub(m.startTime)
+					}
+					m.stats.SetTotalElapsedNs(totalElapsed.Nanoseconds())
+				}
+				if m.tmuxBar != nil {
+					m.tmuxBar.Restore()
+				}
+				m.quitting = true
+				return m, tea.Quit
+			default:
+				// Ignore all other keys while modal is open
+				return m, nil
+			}
+		}
+
 		switch msg.String() {
 		case "q", "ctrl+c":
 			// Persist total elapsed time to stats before quitting
@@ -629,6 +700,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.totalLoops--
 				m.loop.SetIterations(m.totalLoops)
 			}
+			return m, nil
+		case "D":
+			// Open the delete-plan confirmation modal
+			m.confirmDeletePlan = true
 			return m, nil
 		}
 
@@ -953,7 +1028,45 @@ func (m Model) View() string {
 	}
 
 	// Render the main layout
-	return m.renderLayout()
+	layout := m.renderLayout()
+
+	// Overlay the delete-plan confirmation modal if active
+	if m.confirmDeletePlan {
+		return m.renderDeletePlanModal(layout)
+	}
+
+	return layout
+}
+
+// renderDeletePlanModal overlays a centered y/n confirmation modal on top of the
+// main layout asking the user to confirm deleting the implementation plan file.
+func (m Model) renderDeletePlanModal(layout string) string {
+	modalStyle := lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(colorRed).
+		Padding(1, 2).
+		Background(colorDimGray).
+		Foreground(colorLightGray)
+
+	titleStyle := lipgloss.NewStyle().Bold(true).Foreground(colorRed)
+	hintStyle := lipgloss.NewStyle().Foreground(colorDimGray)
+
+	lines := []string{
+		titleStyle.Render("Delete IMPLEMENTATION_PLAN.md?"),
+		"",
+		"This will delete the plan file and reset the loop",
+		"so the agent re-creates it from scratch.",
+		"",
+		hintStyle.Render("y = confirm   n = cancel"),
+	}
+	modalContent := strings.Join(lines, "\n")
+	modal := modalStyle.Render(modalContent)
+
+	// Center the modal on the terminal
+	return lipgloss.Place(m.width, m.height, lipgloss.Center, lipgloss.Center, modal,
+		lipgloss.WithWhitespaceChars(" "),
+		lipgloss.WithWhitespaceForeground(colorDimGray),
+	)
 }
 
 // renderLayout creates the full layout with activity panel and footer
@@ -1141,6 +1254,7 @@ func (m Model) renderFooter() string {
 	resumeKey := dimStyle.Render("(r)esume")
 	loopsKey := highlightStyle.Render("(+)/(-)")
 	loopsLabel := highlightStyle.Render(" # of loops")
+	deleteKey := dimStyle.Render("(D)elete plan")
 
 	// Illuminate resume/start depending on state
 	hasPendingLoops := m.completed && m.totalLoops > m.currentLoop
@@ -1159,7 +1273,7 @@ func (m Model) renderFooter() string {
 		Width(m.width - 2).
 		Align(lipgloss.Left).
 		PaddingLeft(1).
-		Render(fmt.Sprintf("%s%s   %s   %s   %s%s", quitKey, quitLabel, resumeKey, pauseKey, loopsKey, loopsLabel))
+		Render(fmt.Sprintf("%s%s   %s   %s   %s%s   %s", quitKey, quitLabel, resumeKey, pauseKey, loopsKey, loopsLabel, deleteKey))
 
 	return lipgloss.JoinVertical(
 		lipgloss.Left,

--- a/tests/loop_test.go
+++ b/tests/loop_test.go
@@ -2183,3 +2183,267 @@ func TestHibernateRetryEmitsRetryMarker(t *testing.T) {
 		t.Error("Expected a normal LOOP marker after the RETRY marker (second iteration)")
 	}
 }
+
+// TestResetMidExecutionRestartFromIteration1 verifies that calling Reset()
+// while an iteration is executing interrupts it and restarts from iteration 1
+// with a LOOP RESET marker followed by a fresh LOOP 1/N marker.
+func TestResetMidExecutionRestartFromIteration1(t *testing.T) {
+	cfg := loop.Config{
+		Iterations:     3,
+		Prompt:         "test",
+		CommandBuilder: mockMediumSlowCommandBuilder,
+		SleepDuration:  10 * time.Millisecond,
+	}
+
+	l := loop.New(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	l.Start(ctx)
+	output := l.Output()
+
+	// Wait for the first iteration to start executing (system message means
+	// the claude process is running)
+	for msg := range output {
+		if msg.Type == "output" && strings.Contains(msg.Content, `"type":"system"`) {
+			break
+		}
+	}
+
+	// Reset mid-execution (medium-slow mock sleeps 200ms after system message)
+	l.Reset()
+
+	// We should see a LOOP RESET marker, then a fresh LOOP 1/3 marker
+	resetMarkerFound := false
+	firstIterationAfterReset := -1
+	for msg := range output {
+		if msg.Type == "loop_marker" {
+			if strings.Contains(msg.Content, "RESET") {
+				resetMarkerFound = true
+			} else if resetMarkerFound && strings.Contains(msg.Content, "/") {
+				firstIterationAfterReset = msg.Loop
+				break
+			}
+		}
+		if msg.Type == "complete" {
+			cancel()
+		}
+	}
+
+	if !resetMarkerFound {
+		t.Error("Expected a LOOP RESET marker after Reset()")
+	}
+	if firstIterationAfterReset != 1 {
+		t.Errorf("Expected first iteration after reset to be 1, got %d", firstIterationAfterReset)
+	}
+
+	// Drain remaining messages
+	for msg := range output {
+		if msg.Type == "complete" {
+			cancel()
+		}
+	}
+}
+
+// TestResetFromPausedState verifies that Reset() works when the loop is paused.
+// The loop should wake from pause and restart from iteration 1.
+func TestResetFromPausedState(t *testing.T) {
+	cfg := loop.Config{
+		Iterations:     3,
+		Prompt:         "test",
+		CommandBuilder: mockMediumSlowCommandBuilder,
+		SleepDuration:  10 * time.Millisecond,
+	}
+
+	l := loop.New(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	l.Start(ctx)
+	output := l.Output()
+
+	// Wait for the first iteration to start, then pause mid-execution
+	for msg := range output {
+		if msg.Type == "output" && strings.Contains(msg.Content, `"type":"system"`) {
+			break
+		}
+	}
+	l.Pause()
+
+	// Wait for STOPPED marker
+	for msg := range output {
+		if msg.Type == "loop_marker" && strings.Contains(msg.Content, "STOPPED") {
+			break
+		}
+	}
+
+	// Now reset from paused state
+	l.Reset()
+
+	// Should see RESET marker then LOOP 1/3
+	resetMarkerFound := false
+	firstIterationAfterReset := -1
+	for msg := range output {
+		if msg.Type == "loop_marker" {
+			if strings.Contains(msg.Content, "RESET") {
+				resetMarkerFound = true
+			} else if resetMarkerFound && strings.Contains(msg.Content, "/") {
+				firstIterationAfterReset = msg.Loop
+				break
+			}
+		}
+		if msg.Type == "complete" {
+			cancel()
+		}
+	}
+
+	if !resetMarkerFound {
+		t.Error("Expected a LOOP RESET marker after Reset() from paused state")
+	}
+	if firstIterationAfterReset != 1 {
+		t.Errorf("Expected first iteration after reset to be 1, got %d", firstIterationAfterReset)
+	}
+
+	// Drain
+	for msg := range output {
+		if msg.Type == "complete" {
+			cancel()
+		}
+	}
+}
+
+// TestResetFromCompletedWaiting verifies that Reset() works when the loop has
+// completed all iterations and is waiting for more. The loop should restart
+// from iteration 1.
+func TestResetFromCompletedWaiting(t *testing.T) {
+	cfg := loop.Config{
+		Iterations:     2,
+		Prompt:         "test",
+		CommandBuilder: mockCommandBuilder,
+		SleepDuration:  10 * time.Millisecond,
+	}
+
+	l := loop.New(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	l.Start(ctx)
+	output := l.Output()
+
+	// Wait for completion
+	for msg := range output {
+		if msg.Type == "complete" {
+			break
+		}
+	}
+
+	// Verify the loop is in completed-waiting state
+	if !l.IsCompletedWaiting() {
+		t.Fatal("Expected loop to be in completed-waiting state after all iterations")
+	}
+
+	// Reset from completed-waiting
+	l.Reset()
+
+	// Should see RESET marker then LOOP 1/2
+	resetMarkerFound := false
+	firstIterationAfterReset := -1
+	for msg := range output {
+		if msg.Type == "loop_marker" {
+			if strings.Contains(msg.Content, "RESET") {
+				resetMarkerFound = true
+			} else if resetMarkerFound && strings.Contains(msg.Content, "/") {
+				firstIterationAfterReset = msg.Loop
+				break
+			}
+		}
+		if msg.Type == "complete" {
+			cancel()
+		}
+	}
+
+	if !resetMarkerFound {
+		t.Error("Expected a LOOP RESET marker after Reset() from completed-waiting")
+	}
+	if firstIterationAfterReset != 1 {
+		t.Errorf("Expected first iteration after reset to be 1, got %d", firstIterationAfterReset)
+	}
+
+	// Drain
+	for msg := range output {
+		if msg.Type == "complete" {
+			cancel()
+		}
+	}
+}
+
+// TestResetClearsResumeSessionID verifies that after Reset(), the next iteration
+// does NOT use --resume (the session starts fresh).
+func TestResetClearsResumeSessionID(t *testing.T) {
+	cfg := loop.Config{
+		Iterations:     3,
+		Prompt:         "test",
+		CommandBuilder: mockMediumSlowCommandBuilder,
+		SleepDuration:  10 * time.Millisecond,
+	}
+
+	l := loop.New(cfg)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	l.Start(ctx)
+	output := l.Output()
+
+	// Wait for the first iteration to start executing
+	for msg := range output {
+		if msg.Type == "output" && strings.Contains(msg.Content, `"type":"system"`) {
+			break
+		}
+	}
+
+	// Pause to capture a session ID for resume
+	l.Pause()
+	for msg := range output {
+		if msg.Type == "loop_marker" && strings.Contains(msg.Content, "STOPPED") {
+			break
+		}
+	}
+
+	// The loop should have captured a resumeSessionID
+	// Now reset instead of resuming
+	l.Reset()
+
+	// Collect output messages after reset — verify session is "fresh-session-001"
+	// (not a resumed session), proving --resume was NOT used
+	resetMarkerFound := false
+	freshSessionFound := false
+	for msg := range output {
+		if msg.Type == "loop_marker" {
+			if strings.Contains(msg.Content, "RESET") {
+				resetMarkerFound = true
+			}
+		}
+		if msg.Type == "output" && resetMarkerFound {
+			if strings.Contains(msg.Content, "fresh-session-001") {
+				freshSessionFound = true
+				cancel()
+				break
+			}
+		}
+		if msg.Type == "complete" {
+			cancel()
+		}
+	}
+
+	if !resetMarkerFound {
+		t.Error("Expected a LOOP RESET marker")
+	}
+	if !freshSessionFound {
+		t.Error("Expected fresh session after Reset() (no --resume), but did not find fresh-session-001")
+	}
+
+	// Drain
+	for range output {
+	}
+}
+

--- a/tests/tui_test.go
+++ b/tests/tui_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -1760,3 +1761,184 @@ func TestRoleLoopStoppedStyle(t *testing.T) {
 		t.Error("Style for RoleLoopStopped rendered empty string")
 	}
 }
+
+// TestDeletePlanHotkeyOpensModal tests that pressing 'D' opens the confirmation
+// modal and the view shows the confirmation prompt.
+func TestDeletePlanHotkeyOpensModal(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	// Press 'D' to open the modal
+	keyD := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}}
+	model, _ = updateModel(model, keyD)
+
+	// View should contain the confirmation text
+	view := model.View()
+	if !strings.Contains(view, "Delete IMPLEMENTATION_PLAN.md?") {
+		t.Error("View should show delete-plan confirmation modal after pressing 'D'")
+	}
+}
+
+// TestDeletePlanModalCancel tests that pressing 'n' closes the modal without
+// deleting anything or resetting the loop.
+func TestDeletePlanModalCancel(t *testing.T) {
+	// Create a temp plan file
+	tmpDir := t.TempDir()
+	planPath := filepath.Join(tmpDir, "IMPLEMENTATION_PLAN.md")
+	os.WriteFile(planPath, []byte("# Plan\n## TASK 1: Test\n**Status: TODO**\n"), 0644)
+
+	cfg := loop.Config{
+		Iterations:     100,
+		Prompt:         "test",
+		CommandBuilder: mockCommandBuilder,
+		SleepDuration:  10 * time.Millisecond,
+	}
+	l := loop.New(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	model := tui.NewModel()
+	model.SetLoop(l)
+	model.SetPlanFile(planPath)
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	// Drain loop output
+	go func() {
+		for range l.Output() {
+		}
+	}()
+	l.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	// Open modal
+	keyD := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}}
+	model, _ = updateModel(model, keyD)
+
+	// Cancel with 'n'
+	keyN := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'n'}}
+	model, _ = updateModel(model, keyN)
+
+	// View should NOT contain the modal anymore
+	view := model.View()
+	if strings.Contains(view, "Delete IMPLEMENTATION_PLAN.md?") {
+		t.Error("Modal should be closed after pressing 'n'")
+	}
+
+	// Plan file should still exist
+	if _, err := os.Stat(planPath); err != nil {
+		t.Error("Plan file should still exist after canceling delete")
+	}
+}
+
+// TestDeletePlanModalConfirm tests that pressing 'y' deletes the plan file and
+// calls Reset() on the loop.
+func TestDeletePlanModalConfirm(t *testing.T) {
+	// Create a temp plan file
+	tmpDir := t.TempDir()
+	planPath := filepath.Join(tmpDir, "IMPLEMENTATION_PLAN.md")
+	os.WriteFile(planPath, []byte("# Plan\n## TASK 1: Test\n**Status: TODO**\n"), 0644)
+
+	cfg := loop.Config{
+		Iterations:     100,
+		Prompt:         "test",
+		CommandBuilder: mockCommandBuilder,
+		SleepDuration:  10 * time.Millisecond,
+	}
+	l := loop.New(cfg)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	model := tui.NewModel()
+	model.SetLoop(l)
+	model.SetPlanFile(planPath)
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	// Drain loop output
+	go func() {
+		for range l.Output() {
+		}
+	}()
+	l.Start(ctx)
+	time.Sleep(50 * time.Millisecond)
+
+	// Open modal
+	keyD := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}}
+	model, _ = updateModel(model, keyD)
+
+	// Confirm with 'y'
+	keyY := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'y'}}
+	model, _ = updateModel(model, keyY)
+
+	// Plan file should be deleted
+	if _, err := os.Stat(planPath); !os.IsNotExist(err) {
+		t.Error("Plan file should be deleted after confirming with 'y'")
+	}
+
+	// Modal should be closed
+	view := model.View()
+	if strings.Contains(view, "Delete IMPLEMENTATION_PLAN.md?") {
+		t.Error("Modal should be closed after confirming with 'y'")
+	}
+}
+
+// TestDeletePlanModalBlocksOtherKeys tests that when the modal is open, normal
+// hotkeys like 'p' and 'r' are ignored.
+func TestDeletePlanModalBlocksOtherKeys(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	// Open modal
+	keyD := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}}
+	model, _ = updateModel(model, keyD)
+
+	// Press 'p' — should be ignored (modal stays open)
+	keyP := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}}
+	model, _ = updateModel(model, keyP)
+
+	view := model.View()
+	if !strings.Contains(view, "Delete IMPLEMENTATION_PLAN.md?") {
+		t.Error("Modal should still be open after pressing 'p' (ignored while modal is active)")
+	}
+
+	// Press 'r' — should also be ignored
+	keyR := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}
+	model, _ = updateModel(model, keyR)
+
+	view = model.View()
+	if !strings.Contains(view, "Delete IMPLEMENTATION_PLAN.md?") {
+		t.Error("Modal should still be open after pressing 'r' (ignored while modal is active)")
+	}
+}
+
+// TestDeletePlanModalQuitStillWorks tests that 'q' / ctrl+c still quits even
+// when the modal is open.
+func TestDeletePlanModalQuitStillWorks(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	// Open modal
+	keyD := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}}
+	model, _ = updateModel(model, keyD)
+
+	// Press 'q' — should quit
+	keyQ := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}}
+	model, _ = updateModel(model, keyQ)
+
+	view := model.View()
+	if view != "Goodbye!\n" {
+		t.Error("Pressing 'q' from the modal should quit the application")
+	}
+}
+
+// TestDeletePlanHotkeyInHotkeyBar tests that the (D)elete plan hotkey hint
+// appears in the footer.
+func TestDeletePlanHotkeyInHotkeyBar(t *testing.T) {
+	model := tui.NewModel()
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+
+	view := model.View()
+	if !strings.Contains(view, "(D)") {
+		t.Error("Footer hotkey bar should show (D)elete plan hint")
+	}
+}
+


### PR DESCRIPTION
## Summary
Adds a TUI hotkey to delete `IMPLEMENTATION_PLAN.md` and restart the loop from iteration 1 with a fresh session, so the agent re-creates the plan from scratch.

## Changes
- **loop** (`internal/loop/loop.go`): new `Loop.Reset()` + `consumeResetRequest()` helper that emits a `======= LOOP RESET =======` marker. Reset clears `resumeSessionID` (no `--resume`), unpauses, cancels the in-flight iteration, and wakes the run goroutine. Handled at three check-points: during execution, from a pause, and from the completed-waiting state.
- **tui** (`internal/tui/tui.go`): `D` opens a centered y/n confirmation modal. Confirming deletes the plan file, calls `Reset()`, clears task/completed state, and resumes timers. The modal blocks other hotkeys but still allows quit (`q`/`ctrl+c`). Footer shows the `(D)elete plan` hint.
- **main** (`cmd/ralph/main.go`): wires `SetPlanFile()` in `main()` and `runPlanAndBuild()`, and treats `RESET` markers as non-new-loop starts.

## Tests
- `tests/loop_test.go`: `Reset()` across mid-execution, paused, and completed-waiting states, plus fresh-session (no `--resume`) verification.
- `tests/tui_test.go`: modal open / cancel / confirm, key-blocking, quit-from-modal, and footer hint.
- `cmd/ralph/main_test.go`: `LOOP RESET` marker case.

`go vet ./...`, build, and full test suite all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)