### PR TITLE
feat(tui): even 1:1 main-pane split, four equal footer panels

### DIFF
--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -241,8 +241,8 @@ type Model struct {
 	loopBaseElapsed   time.Duration // per-loop elapsed from before pause within same loop
 	loopTimerPaused   bool          // whether per-loop timer is paused
 	loopPausedElapsed time.Duration // per-loop elapsed at time of pause
-	thinkingViewport  viewport.Model // left pane (2:1): thinking/assistant narrative, word-wrapped
-	toolViewport      viewport.Model // right pane (1:1): tool-use rows + plan panel
+	thinkingViewport  viewport.Model // left half of the 1:1 split: thinking/assistant narrative, word-wrapped
+	toolViewport      viewport.Model // right half of the 1:1 split: tool-use rows + plan panel
 	activityHeight    int
 	footerHeight      int
 	msgChan           <-chan Message
@@ -271,7 +271,7 @@ func NewModel() Model {
 		startTime:      now,
 		loopStartTime:  now,
 		activityHeight: 0,
-		footerHeight:   11,
+		footerHeight:   8,
 	}
 }
 
@@ -472,12 +472,12 @@ func waitForDone(ch <-chan struct{}) tea.Cmd {
 	}
 }
 
-// splitPaneWidths divides the activity row into a 2:1 (thinking : tool) split.
+// splitPaneWidths divides the activity row into a 1:1 (thinking : tool) split.
 // Each returned outer width gets a +2 rounded border when rendered, so
 // left + right + 4 == width and the joined row fills the terminal exactly. Both
 // are floored at 1 so a tiny terminal can't produce a zero/negative dimension.
 func splitPaneWidths(width int) (left, right int) {
-	left = max((width-4)*2/3, 1)
+	left = max((width-4)/2, 1)
 	right = max((width-4)-left, 1)
 	return left, right
 }
@@ -518,8 +518,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			return m, nil
 		}
 
-		// Split the activity area 2:1 — a wide "thinking" pane and a narrow
-		// "tool use" pane (see splitPaneWidths). The inner viewport width is the
+		// Split the activity area 1:1 — a "thinking" pane and a "tool use"
+		// pane (see splitPaneWidths). The inner viewport width is the
 		// box width minus its rounded border (+2) and horizontal padding (+2).
 		leftStyleWidth, rightStyleWidth := splitPaneWidths(m.width)
 		leftVpWidth := max(leftStyleWidth-4, 1)
@@ -844,7 +844,7 @@ func renderNarrativeLine(msg Message, width int) string {
 	return lipgloss.JoinHorizontal(lipgloss.Top, gutter, body)
 }
 
-// renderThinkingContent renders the left (2/3) pane: the thinking/assistant
+// renderThinkingContent renders the left pane: the thinking/assistant
 // narrative — every non-tool message word-wrapped to the pane width — plus the
 // idle "thinking…" indicator. Tool-use rows live in the right pane instead.
 func (m Model) renderThinkingContent() string {
@@ -891,7 +891,7 @@ func (m Model) renderThinkingContent() string {
 	return strings.Join(lines, "\n")
 }
 
-// renderToolContent renders the right (1/3) pane: the agent's plan panel pinned
+// renderToolContent renders the right pane: the agent's plan panel pinned
 // at the top followed by the tool-use rows, each rendered exactly as before the
 // split (status glyph + kind icon + title + dim elapsed time).
 func (m Model) renderToolContent() string {
@@ -976,9 +976,9 @@ func (m Model) renderLayout() string {
 		statusText = "STOPPED"
 	}
 
-	// Split the activity area 2:1 — a wide "thinking" pane and a narrow
-	// "tool use" pane (see splitPaneWidths); each box's +2 rounded border makes
-	// the joined row fill the terminal exactly.
+	// Split the activity area 1:1 — a "thinking" pane and a "tool use" pane
+	// (see splitPaneWidths); each box's +2 rounded border makes the joined row
+	// fill the terminal exactly.
 	leftStyleWidth, rightStyleWidth := splitPaneWidths(m.width)
 
 	paneStyle := lipgloss.NewStyle().
@@ -1017,10 +1017,11 @@ func (m Model) renderLayout() string {
 	)
 }
 
-// renderFooter renders the two-panel footer with hotkey bar
+// renderFooter renders the four-panel footer with hotkey bar
 func (m Model) renderFooter() string {
-	// Calculate panel width (divide by 2, accounting for spacing)
-	panelWidth := (m.width - 6) / 2
+	// Four equal panels; each +2 rounded border makes 4*(panelWidth+2) fill
+	// the terminal width (minus the integer-division remainder).
+	panelWidth := max((m.width-8)/4, 1)
 
 	// Panel styles
 	panelStyle := lipgloss.NewStyle().
@@ -1031,9 +1032,7 @@ func (m Model) renderFooter() string {
 		Height(m.footerHeight - 3) // Leave room for hotkey bar
 
 	labelStyle := lipgloss.NewStyle().
-		Foreground(colorBlue).
-		Align(lipgloss.Right).
-		Width(17)
+		Foreground(colorBlue)
 
 	valueStyle := lipgloss.NewStyle().
 		Foreground(colorLightGray)
@@ -1046,21 +1045,33 @@ func (m Model) renderFooter() string {
 		Bold(true).
 		Foreground(colorPurple)
 
+	// row renders one "Label: value" line. Labels are left-aligned with no
+	// fixed gutter so the quarter-width panels keep as much room as possible
+	// for values; anything longer word-wraps within the panel.
+	row := func(label, value string, vs lipgloss.Style) string {
+		return lipgloss.JoinHorizontal(lipgloss.Left, labelStyle.Render(label), vs.Render(" "+value))
+	}
+
 	// Take a consistent snapshot of stats for display (avoids races with writer goroutine)
 	snap := m.stats.Snapshot()
 
-	// Usage & Cost panel
-	usageCostContent := lipgloss.JoinVertical(
+	// Token Usage panel
+	tokenUsagePanel := panelStyle.Render(lipgloss.JoinVertical(
 		lipgloss.Left,
-		titleStyle.Render("Usage & Cost"),
-		lipgloss.JoinHorizontal(lipgloss.Left, labelStyle.Render("Total Tokens:"), valueStyle.Render(fmt.Sprintf(" %s", stats.FormatTokens(snap.TotalTokensCount)))),
-		lipgloss.JoinHorizontal(lipgloss.Left, labelStyle.Render("Input:"), valueStyle.Render(fmt.Sprintf(" %s", stats.FormatTokens(snap.InputTokens)))),
-		lipgloss.JoinHorizontal(lipgloss.Left, labelStyle.Render("Output:"), valueStyle.Render(fmt.Sprintf(" %s", stats.FormatTokens(snap.OutputTokens)))),
-		lipgloss.JoinHorizontal(lipgloss.Left, labelStyle.Render("Cache Write:"), valueStyle.Render(fmt.Sprintf(" %s", stats.FormatTokens(snap.CacheCreationTokens)))),
-		lipgloss.JoinHorizontal(lipgloss.Left, labelStyle.Render("Cache Read:"), valueStyle.Render(fmt.Sprintf(" %s", stats.FormatTokens(snap.CacheReadTokens)))),
-		lipgloss.JoinHorizontal(lipgloss.Left, labelStyle.Render("Total Cost:"), costStyle.Render(fmt.Sprintf(" $%.6f", snap.TotalCostUSD))),
-	)
-	usageCostPanel := panelStyle.Render(usageCostContent)
+		titleStyle.Render("Token Usage"),
+		row("Total Tokens:", stats.FormatTokens(snap.TotalTokensCount), valueStyle),
+		row("Input:", stats.FormatTokens(snap.InputTokens), valueStyle),
+		row("Output:", stats.FormatTokens(snap.OutputTokens), valueStyle),
+	))
+
+	// Cache & Cost panel
+	cacheCostPanel := panelStyle.Render(lipgloss.JoinVertical(
+		lipgloss.Left,
+		titleStyle.Render("Cache & Cost"),
+		row("Cache Write:", stats.FormatTokens(snap.CacheCreationTokens), valueStyle),
+		row("Cache Read:", stats.FormatTokens(snap.CacheReadTokens), valueStyle),
+		row("Total Cost:", fmt.Sprintf("$%.6f", snap.TotalCostUSD), costStyle),
+	))
 
 	// Loop Details panel
 	loopDisplay := "#0/0"
@@ -1097,38 +1108,39 @@ func (m Model) renderFooter() string {
 		statusStyle = valueStyle.Foreground(colorRed)
 	}
 
-	// Current Mode display
-	modeDisplay := " -"
-	if m.currentMode != "" {
-		modeDisplay = fmt.Sprintf(" %s", m.currentMode)
-	}
-
-	// Completed Tasks display
-	completedDisplay := fmt.Sprintf(" %d/%d", m.completedTasks, m.totalTasks)
-
-	// Current Task display
-	taskDisplay := " -"
-	if m.currentTask != "" {
-		taskDisplay = fmt.Sprintf(" %s", m.currentTask)
-	}
-
-	loopDetailsContent := lipgloss.JoinVertical(
+	loopDetailsPanel := panelStyle.Render(lipgloss.JoinVertical(
 		lipgloss.Left,
 		titleStyle.Render("Ralph Loop Details"),
-		lipgloss.JoinHorizontal(lipgloss.Left, labelStyle.Render("Loop:"), valueStyle.Render(fmt.Sprintf(" %s", loopDisplay))),
-		lipgloss.JoinHorizontal(lipgloss.Left, labelStyle.Render("Total Time:"), valueStyle.Render(fmt.Sprintf(" %s", timeDisplay))),
-		lipgloss.JoinHorizontal(lipgloss.Left, labelStyle.Render("Status:"), statusStyle.Render(fmt.Sprintf(" %s", statusText))),
-		lipgloss.JoinHorizontal(lipgloss.Left, labelStyle.Render("Completed Tasks:"), valueStyle.Render(completedDisplay)),
-		lipgloss.JoinHorizontal(lipgloss.Left, labelStyle.Render("Current Task:"), valueStyle.Render(taskDisplay)),
-		lipgloss.JoinHorizontal(lipgloss.Left, labelStyle.Render("Current Mode:"), valueStyle.Render(modeDisplay)),
-	)
-	loopDetailsPanel := panelStyle.Render(loopDetailsContent)
+		row("Loop:", loopDisplay, valueStyle),
+		row("Total Time:", timeDisplay, valueStyle),
+		row("Status:", statusText, statusStyle),
+	))
+
+	// Task Progress panel
+	modeDisplay := "-"
+	if m.currentMode != "" {
+		modeDisplay = m.currentMode
+	}
+	taskDisplay := "-"
+	if m.currentTask != "" {
+		taskDisplay = m.currentTask
+	}
+
+	taskProgressPanel := panelStyle.Render(lipgloss.JoinVertical(
+		lipgloss.Left,
+		titleStyle.Render("Task Progress"),
+		row("Completed Tasks:", fmt.Sprintf("%d/%d", m.completedTasks, m.totalTasks), valueStyle),
+		row("Current Task:", taskDisplay, valueStyle),
+		row("Current Mode:", modeDisplay, valueStyle),
+	))
 
 	// Join panels horizontally
 	panels := lipgloss.JoinHorizontal(
 		lipgloss.Top,
-		usageCostPanel,
+		tokenUsagePanel,
+		cacheCostPanel,
 		loopDetailsPanel,
+		taskProgressPanel,
 	)
 
 	// Hotkey bar

--- a/tests/bdd_monitor_progress_test.go
+++ b/tests/bdd_monitor_progress_test.go
@@ -319,13 +319,16 @@ func TestBDD_UserMonitorsBuildProgress_CurrentTaskUpdates(t *testing.T) {
 	// When: task is updated via message
 	m, _ = sendTuiMsg(m, tui.SendTaskUpdate("#6 Refactor config module"))
 
-	// Then: footer shows the task text
+	// Then: footer shows the task text (word-wrapped inside the quarter-width
+	// Task Progress panel, so assert the segments rather than one long line)
 	view := m.View()
 	if !strings.Contains(view, "Current Task:") {
 		t.Errorf("Expected 'Current Task:' label in footer")
 	}
-	if !strings.Contains(view, "#6 Refactor config module") {
-		t.Errorf("Expected task text in footer, got:\n%s", view)
+	for _, segment := range []string{"#6 Refactor", "config module"} {
+		if !strings.Contains(view, segment) {
+			t.Errorf("Expected task text segment %q in footer, got:\n%s", segment, view)
+		}
 	}
 }
 
@@ -425,7 +428,10 @@ func TestBDD_UserMonitorsBuildProgress_FooterFieldOrdering(t *testing.T) {
 	// When: the view is rendered
 	view := m.View()
 
-	// Then: fields appear in the correct order within the Ralph Loop Details panel
+	// Then: fields appear in the correct order within their panels. The footer
+	// panels sit side by side, so the view string interleaves them row by row:
+	// vertical order within a panel means a strictly increasing index, and the
+	// Ralph Loop Details panel sits left of the Task Progress panel.
 	loopIdx := strings.Index(view, "Loop:")
 	timeIdx := strings.Index(view, "Total Time:")
 	statusIdx := strings.Index(view, "Status:")
@@ -439,10 +445,17 @@ func TestBDD_UserMonitorsBuildProgress_FooterFieldOrdering(t *testing.T) {
 			loopIdx, timeIdx, statusIdx, completedIdx, taskIdx, modeIdx)
 	}
 
-	if !(loopIdx < timeIdx && timeIdx < statusIdx &&
-		statusIdx < completedIdx && completedIdx < taskIdx && taskIdx < modeIdx) {
-		t.Errorf("Footer fields not in expected order: Loop@%d < Time@%d < Status@%d < Completed@%d < Task@%d < Mode@%d",
-			loopIdx, timeIdx, statusIdx, completedIdx, taskIdx, modeIdx)
+	if !(loopIdx < timeIdx && timeIdx < statusIdx) {
+		t.Errorf("Ralph Loop Details fields not in vertical order: Loop@%d < Time@%d < Status@%d",
+			loopIdx, timeIdx, statusIdx)
+	}
+	if !(completedIdx < taskIdx && taskIdx < modeIdx) {
+		t.Errorf("Task Progress fields not in vertical order: Completed@%d < Task@%d < Mode@%d",
+			completedIdx, taskIdx, modeIdx)
+	}
+	if !(loopIdx < completedIdx) {
+		t.Errorf("Ralph Loop Details panel should be left of Task Progress panel: Loop@%d < Completed@%d",
+			loopIdx, completedIdx)
 	}
 }
 

--- a/tests/bdd_terminal_adapt_test.go
+++ b/tests/bdd_terminal_adapt_test.go
@@ -486,8 +486,8 @@ func TestBDD_UserAdaptsToTerminal_ResizeToExactMinimumFromTiny(t *testing.T) {
 	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 40, Height: 15})
 
 	// Then: full layout is shown (not the too-small message)
-	// Note: at 40x15, viewport is only 1 row tall (15 - footerHeight(11) - 2 borders = 2,
-	// vpHeight = max(2-2, 1) = 1), so message content may not fit in the viewport.
+	// Note: at 40x15, viewport is only 3 rows tall (15 - footerHeight(8) - 2 borders = 5,
+	// vpHeight = max(5-2, 1) = 3), so message content may not fit in the viewport.
 	// We verify the layout renders, not that the tiny viewport shows all content.
 	if viewContains(m, "Terminal too small") {
 		t.Error("Should show full layout at exact minimum after resize from tiny")

--- a/tests/tui_split_test.go
+++ b/tests/tui_split_test.go
@@ -37,7 +37,7 @@ func TestSplit_ThinkingWrappedToFullLength(t *testing.T) {
 	model := tui.NewModel()
 	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
 
-	// ~280 chars: comfortably wider than the ~73-col left pane, so it must wrap
+	// ~280 chars: comfortably wider than the ~54-col left pane, so it must wrap
 	// to several lines for the tail to be visible.
 	middle := strings.Repeat("reasoning step and more detail ", 8)
 	content := "THINK_HEAD " + middle + "THINK_TAIL_SENTINEL"

--- a/tests/tui_test.go
+++ b/tests/tui_test.go
@@ -1387,8 +1387,12 @@ func TestCurrentTaskDisplayedInFooter(t *testing.T) {
 	if !strings.Contains(view, "Current Task:") {
 		t.Error("View should contain 'Current Task:' label")
 	}
-	if !strings.Contains(view, "#6 Refactor config") {
-		t.Error("View should display the current task text")
+	// The quarter-width Task Progress panel word-wraps the task text, so
+	// assert the segments rather than one contiguous line.
+	for _, segment := range []string{"#6 Refactor", "config"} {
+		if !strings.Contains(view, segment) {
+			t.Errorf("View should display the current task text segment %q", segment)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Split the main activity row 1:1 between the thinking pane and the tool pane (was 2:1).
- Reorganize the footer's two wide panels into **four equal quarter-width panels**: Token Usage, Cache & Cost, Ralph Loop Details, and Task Progress.
- Each footer panel is a title plus three rows, so the footer shrinks from 11 to 8 rows and the activity area gains 3 rows.
- Footer labels drop the fixed right-aligned 17-column gutter (quarter panels need the room); long values word-wrap inside their panel.

## Layout
```
╭──────────── thinking ────────────╮╭──────────── tool use ────────────╮
│                                  ││                                  │
╰──────────────────────────────────╯╰──────────────────────────────────╯
╭ Token Usage ─╮╭ Cache & Cost ╮╭ Ralph Loop Details ╮╭ Task Progress ─╮
│ Total Tokens ││ Cache Write  ││ Loop               ││ Completed Tasks│
│ Input        ││ Cache Read   ││ Total Time         ││ Current Task   │
│ Output       ││ Total Cost   ││ Status             ││ Current Mode   │
╰──────────────╯╰──────────────╯╰────────────────────╯╰────────────────╯
```

## Test changes
Three tests encoded the old half-width footer layout and were updated to match:
- `TestBDD_UserMonitorsBuildProgress_FooterFieldOrdering` now asserts vertical field order within each panel plus left-to-right panel order (side-by-side panels interleave row-wise in the rendered string).
- `TestBDD_UserMonitorsBuildProgress_CurrentTaskUpdates` and `TestCurrentTaskDisplayedInFooter` assert word-wrapped task-text segments instead of one contiguous line.
- Refreshed stale numeric comments (footerHeight, left-pane width) in two other test files.

`go vet ./...` clean; full suite (`go test ./tests/ ./cmd/ralph/`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)