### PR TITLE
feat: add --model and --effort flags passed to claude each loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@
 
 ## Key Flags
 - `--iterations N` — loop count (default: 5)
+- `--model <model>` — model passed to `claude --model` each iteration (overrides `.claude/settings*.json`; empty = CLI default)
+- `--effort <level>` — effort level passed to `claude --effort` each iteration (overrides `.claude/settings*.json`; empty = CLI default)
 - `--version` — print version and exit
 - `--spec-file` / `--spec-folder` — spec overrides
 - `--loop-prompt` — custom prompt override

--- a/cmd/ralph/main.go
+++ b/cmd/ralph/main.go
@@ -405,6 +405,8 @@ func main() {
 	loopConfig := loop.Config{
 		Iterations: cfg.Iterations,
 		Prompt:     promptContent,
+		Model:      cfg.Model,
+		Effort:     cfg.Effort,
 	}
 
 	// Create the loop
@@ -1121,6 +1123,8 @@ func runCLI(cfg *config.Config, promptContent string, tokenStats *stats.TokenSta
 	claudeLoop := loop.New(loop.Config{
 		Iterations: cfg.Iterations,
 		Prompt:     promptContent,
+		Model:      cfg.Model,
+		Effort:     cfg.Effort,
 	})
 
 	// Startup budget check — wait until rolling window drops below limit
@@ -1290,6 +1294,8 @@ func runPlanAndBuildCLI(cfg *config.Config, tokenStats *stats.TokenStats, logFil
 	planLoop := loop.New(loop.Config{
 		Iterations: cfg.Iterations, // Always 1 for plan phase
 		Prompt:     planPromptContent,
+		Model:      cfg.Model,
+		Effort:     cfg.Effort,
 	})
 	planLoop.Start(ctx)
 
@@ -1387,6 +1393,8 @@ planLoop:
 	buildLoop := loop.New(loop.Config{
 		Iterations: cfg.BuildIterations,
 		Prompt:     buildPromptContent,
+		Model:      cfg.Model,
+		Effort:     cfg.Effort,
 	})
 
 	// Set the resume session ID from the plan phase
@@ -1550,6 +1558,8 @@ func runPlanAndBuildPhases(
 	planLoop := loop.New(loop.Config{
 		Iterations: cfg.Iterations, // Always 1 for plan phase
 		Prompt:     planPromptContent,
+		Model:      cfg.Model,
+		Effort:     cfg.Effort,
 	})
 
 	// Update TUI with planning phase and set loop reference for hotkey control
@@ -1585,6 +1595,8 @@ func runPlanAndBuildPhases(
 	buildLoop := loop.New(loop.Config{
 		Iterations: cfg.BuildIterations,
 		Prompt:     buildPromptContent,
+		Model:      cfg.Model,
+		Effort:     cfg.Effort,
 	})
 
 	// Set the resume session ID from the plan phase

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,8 @@ type Config struct {
 	Goal             string
 	PlanFile         string
 	AutoresearchFile string // path to custom experiment file for autoresearch mode
+	Model            string // model override passed to `claude --model` (empty = CLI default)
+	Effort           string // effort level passed to `claude --effort` (empty = CLI default)
 	ShowPrompt       bool
 	ShowVersion      bool
 	NoTmux           bool
@@ -78,6 +80,8 @@ func ParseFlags() *Config {
 	flag.StringVar(&cfg.LoopPrompt, "loop-prompt", "", "Path to loop prompt override (defaults to embedded prompt.md)")
 	flag.StringVar(&cfg.Goal, "goal", "", "Ultimate goal sentence to guide the agent")
 	flag.StringVar(&cfg.PlanFile, "plan-file", DefaultPlanFile, "Implementation plan filename")
+	flag.StringVar(&cfg.Model, "model", "", "`model` passed to claude --model each iteration (overrides .claude/settings*.json; empty = CLI default)")
+	flag.StringVar(&cfg.Effort, "effort", "", "`level` passed to claude --effort each iteration (overrides .claude/settings*.json; empty = CLI default)")
 	flag.BoolVar(&cfg.ShowPrompt, "show-prompt", false, "Print the embedded loop prompt and exit")
 	flag.BoolVar(&cfg.ShowVersion, "version", false, "Print version and exit")
 	flag.BoolVar(&cfg.NoTmux, "no-tmux", false, "Run without tmux wrapper")

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -19,16 +19,35 @@ import (
 // This allows for dependency injection in tests.
 type CommandBuilder func(ctx context.Context, prompt string) *exec.Cmd
 
-// DefaultCommandBuilder creates the standard claude CLI command.
+// DefaultCommandBuilder creates the standard claude CLI command with no model
+// or effort override (the claude CLI falls back to its own configured defaults).
 func DefaultCommandBuilder(ctx context.Context, prompt string) *exec.Cmd {
-	cmd := exec.CommandContext(ctx, "claude",
-		"--print",
-		"--output-format", "stream-json",
-		"--dangerously-skip-permissions",
-		"--verbose",
-	)
-	cmd.Env = isolatedTmuxEnv()
-	return cmd
+	return NewCommandBuilder("", "")(ctx, prompt)
+}
+
+// NewCommandBuilder returns a CommandBuilder that runs the claude CLI, optionally
+// pinning the model and/or effort level. A non-empty model appends `--model
+// <model>` and a non-empty effort appends `--effort <effort>`; these override
+// any model/effort configured in .claude/settings*.json. Empty values are
+// omitted so the CLI keeps its own defaults.
+func NewCommandBuilder(model, effort string) CommandBuilder {
+	return func(ctx context.Context, prompt string) *exec.Cmd {
+		args := []string{
+			"--print",
+			"--output-format", "stream-json",
+			"--dangerously-skip-permissions",
+			"--verbose",
+		}
+		if model != "" {
+			args = append(args, "--model", model)
+		}
+		if effort != "" {
+			args = append(args, "--effort", effort)
+		}
+		cmd := exec.CommandContext(ctx, "claude", args...)
+		cmd.Env = isolatedTmuxEnv()
+		return cmd
+	}
 }
 
 // isolatedTmuxEnv returns a copy of the current environment with the inherited
@@ -73,6 +92,8 @@ func isolatedTmuxEnv() []string {
 type Config struct {
 	Iterations     int
 	Prompt         string         // The prompt content to send to Claude
+	Model          string         // Model override passed to `claude --model` (empty = CLI default)
+	Effort         string         // Effort level passed to `claude --effort` (empty = CLI default)
 	CommandBuilder CommandBuilder // Optional custom command builder (for testing)
 	SleepDuration  time.Duration  // Duration to sleep between iterations (default: 1s)
 }
@@ -108,7 +129,7 @@ type Loop struct {
 func New(cfg Config) *Loop {
 	// Set defaults
 	if cfg.CommandBuilder == nil {
-		cfg.CommandBuilder = DefaultCommandBuilder
+		cfg.CommandBuilder = NewCommandBuilder(cfg.Model, cfg.Effort)
 	}
 	if cfg.SleepDuration == 0 {
 		cfg.SleepDuration = 1 * time.Second

--- a/tests/loop_test.go
+++ b/tests/loop_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -2477,7 +2478,7 @@ func TestNewCommandBuilder(t *testing.T) {
 			joined := strings.Join(args, " ")
 
 			for _, f := range baseFlags {
-				if !containsArg(args, f) {
+				if !slices.Contains(args, f) {
 					t.Errorf("expected base flag %q in args, got %v", f, args)
 				}
 			}
@@ -2485,26 +2486,17 @@ func TestNewCommandBuilder(t *testing.T) {
 			if got := containsPair(args, "--model", tc.wantModelV); got != tc.wantModel {
 				t.Errorf("--model %q presence = %v, want %v (args: %s)", tc.wantModelV, got, tc.wantModel, joined)
 			}
-			if !tc.wantModel && containsArg(args, "--model") {
+			if !tc.wantModel && slices.Contains(args, "--model") {
 				t.Errorf("did not expect --model in args, got %s", joined)
 			}
 			if got := containsPair(args, "--effort", tc.wantEffortV); got != tc.wantEffort {
 				t.Errorf("--effort %q presence = %v, want %v (args: %s)", tc.wantEffortV, got, tc.wantEffort, joined)
 			}
-			if !tc.wantEffort && containsArg(args, "--effort") {
+			if !tc.wantEffort && slices.Contains(args, "--effort") {
 				t.Errorf("did not expect --effort in args, got %s", joined)
 			}
 		})
 	}
-}
-
-func containsArg(args []string, want string) bool {
-	for _, a := range args {
-		if a == want {
-			return true
-		}
-	}
-	return false
 }
 
 // containsPair reports whether args contains flag immediately followed by value.

--- a/tests/loop_test.go
+++ b/tests/loop_test.go
@@ -2447,3 +2447,72 @@ func TestResetClearsResumeSessionID(t *testing.T) {
 	}
 }
 
+// TestNewCommandBuilder verifies that model/effort overrides are appended to the
+// claude CLI args only when non-empty, and that the base flags are always present.
+func TestNewCommandBuilder(t *testing.T) {
+	baseFlags := []string{"--print", "--output-format", "stream-json", "--dangerously-skip-permissions", "--verbose"}
+
+	tests := []struct {
+		name        string
+		model       string
+		effort      string
+		wantModel   bool
+		wantEffort  bool
+		wantModelV  string
+		wantEffortV string
+	}{
+		{name: "no overrides", model: "", effort: ""},
+		{name: "model only", model: "claude-opus-4-8", wantModel: true, wantModelV: "claude-opus-4-8"},
+		{name: "effort only", effort: "high", wantEffort: true, wantEffortV: "high"},
+		{name: "both", model: "claude-sonnet-5", effort: "low", wantModel: true, wantEffort: true, wantModelV: "claude-sonnet-5", wantEffortV: "low"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			builder := loop.NewCommandBuilder(tc.model, tc.effort)
+			cmd := builder(context.Background(), "prompt")
+
+			// args[0] is the command path ("claude"); the rest are flags.
+			args := cmd.Args[1:]
+			joined := strings.Join(args, " ")
+
+			for _, f := range baseFlags {
+				if !containsArg(args, f) {
+					t.Errorf("expected base flag %q in args, got %v", f, args)
+				}
+			}
+
+			if got := containsPair(args, "--model", tc.wantModelV); got != tc.wantModel {
+				t.Errorf("--model %q presence = %v, want %v (args: %s)", tc.wantModelV, got, tc.wantModel, joined)
+			}
+			if !tc.wantModel && containsArg(args, "--model") {
+				t.Errorf("did not expect --model in args, got %s", joined)
+			}
+			if got := containsPair(args, "--effort", tc.wantEffortV); got != tc.wantEffort {
+				t.Errorf("--effort %q presence = %v, want %v (args: %s)", tc.wantEffortV, got, tc.wantEffort, joined)
+			}
+			if !tc.wantEffort && containsArg(args, "--effort") {
+				t.Errorf("did not expect --effort in args, got %s", joined)
+			}
+		})
+	}
+}
+
+func containsArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+// containsPair reports whether args contains flag immediately followed by value.
+func containsPair(args []string, flag, value string) bool {
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == flag && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
Adds `--model <model>` and `--effort <level>` CLI flags that are passed into every `claude --print` invocation the loop runs. Both override any model/effort configured in `.claude/settings*.json`; when left empty, the flags are omitted so the claude CLI keeps its own configured defaults.

The flags apply across all execution paths — default build (TUI), `--cli`, `plan`, and `plan-and-build` (both plan and build phases).

## Implementation
- `internal/config`: new `Model`/`Effort` fields + `--model`/`--effort` flags.
- `internal/loop`: new `NewCommandBuilder(model, effort)` factory that appends `--model`/`--effort` only when non-empty. `DefaultCommandBuilder` now delegates to it with empty overrides; `loop.New` uses the factory with the config's model/effort when no custom builder is injected.
- `cmd/ralph/main.go`: threads `cfg.Model`/`cfg.Effort` into all six `loop.Config` construction sites.
- Docs: CLAUDE.md Key Flags updated.

## Testing
- `go build`, `go vet ./...` clean.
- `go test ./tests/ ./cmd/ralph/` passes.
- New `TestNewCommandBuilder` table test covers no-override / model-only / effort-only / both, asserting base flags are always present and overrides appear only when set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)