### PR TITLE
feat(tui): Model Details footer panel, per-loop tmux status, hibernate + UTF-8 fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,7 @@
 - Test single: `go test -v -run TestName ./tests/`
 - Test main: `go test -v ./cmd/ralph/`
 - Gotcha: `make test` runs only `./tests` — use `go test ./tests/ ./cmd/ralph/` as the authoritative command
+- Gotcha: Go caches test results — add `-count=1` to force a real re-run (required for mutation testing, or a broken mutant "passes" from cache)
 
 ## Project Structure
 - `cmd/ralph/main.go` — entry point, wires loop/parser/tui together

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,9 +3,11 @@
 ## Build & Test
 - Build: `go build -o ralph ./cmd/ralph`
 - Vet: `go vet ./...` (must be clean)
+- Format: `gofmt -l .` (must print nothing)
 - Test all: `go test -v ./tests/ ./cmd/ralph/`
 - Test single: `go test -v -run TestName ./tests/`
 - Test main: `go test -v ./cmd/ralph/`
+- Gotcha: `make test` runs only `./tests` — use `go test ./tests/ ./cmd/ralph/` as the authoritative command
 
 ## Project Structure
 - `cmd/ralph/main.go` — entry point, wires loop/parser/tui together
@@ -17,7 +19,7 @@
 - `internal/tmux/` — auto-wrap in tmux session
 - `internal/tui/` — BubbleTea TUI (activity panel, footer, hotkeys)
 - `tests/` — BDD and unit tests for internal packages
-- `cmd/ralph/main_test.go` — tests for main.go functions (parseTaskCounts, isNewLoopStart)
+- `cmd/ralph/main_test.go` — tests for main.go functions (isNewLoopStart, isRetryLoopStart, checkCostPacing)
 - `specs/` — feature specifications
 
 ## Subcommands

--- a/cmd/ralph/main.go
+++ b/cmd/ralph/main.go
@@ -424,7 +424,7 @@ func main() {
 	model.SetTmuxStatusBar(tmuxBar)
 	model.SetGitContext(dbCtx.repo, dbCtx.branch)
 	model.SetPlanFile(cfg.PlanFile)
-	model.SetModelInfo(cfg.Model, cfg.Effort)
+	model.SetModelInfo(cfg.Model, config.ResolveEffort(cfg.Effort))
 
 	// Set current mode for TUI display
 	if cfg.IsPlanMode() {
@@ -540,6 +540,46 @@ func processLoopOutput(
 	}
 }
 
+// transcriptEffortInterval and transcriptEffortAttempts bound the wait for the
+// claude CLI to write its first assistant record, which is where the transcript
+// first names the effort level. ~30s covers a slow first turn; giving up leaves
+// the settings-derived value in the panel.
+const (
+	transcriptEffortInterval = 500 * time.Millisecond
+	transcriptEffortAttempts = 60
+)
+
+// trackSession records the session ID for --resume support and, whenever the
+// session changes, starts one background read of that session's transcript for
+// the effort level the CLI resolved. An empty ID means the message did not
+// carry one and is ignored.
+func trackSession(claudeLoop *loop.Loop, sessionID string, program *tea.Program) {
+	if sessionID == "" {
+		return
+	}
+	// GetSessionID still holds the previous session here, so this fires once
+	// per session rather than once per system message.
+	if program != nil && sessionID != claudeLoop.GetSessionID() {
+		go refineEffortFromTranscript(sessionID, program)
+	}
+	claudeLoop.SetSessionID(sessionID)
+}
+
+// refineEffortFromTranscript polls the session transcript until the claude CLI
+// records the effort level it is running at, then reports it to the Model
+// Details panel. The stream never carries the effort, so this readback is the
+// only runtime source; it is best-effort and silently gives up, since the panel
+// already shows the level resolved from --effort or the settings chain.
+func refineEffortFromTranscript(sessionID string, program *tea.Program) {
+	for range transcriptEffortAttempts {
+		if effort := config.TranscriptEffort(sessionID); effort != "" {
+			program.Send(tui.SendEffortUpdate(effort)())
+			return
+		}
+		time.Sleep(transcriptEffortInterval)
+	}
+}
+
 // processMessage handles a single message from the loop
 func processMessage(
 	msg loop.Message,
@@ -573,9 +613,7 @@ func processMessage(
 		parsed := jsonParser.ParseLine(msg.Content)
 		if parsed != nil {
 			// Capture session ID from system messages for --resume support
-			if sessionID := jsonParser.GetSessionID(parsed); sessionID != "" {
-				claudeLoop.SetSessionID(sessionID)
-			}
+			trackSession(claudeLoop, jsonParser.GetSessionID(parsed), program)
 			handleParsedMessage(parsed, claudeLoop, jsonParser, tokenStats, msgChan, program, loopTotalTokens, logFile, iterEstimate, subagentCostAccum, lastResultCost, iterToolUseCount, noopStreak, apiBackoff, seenMsgIDs)
 		} else {
 			// Check if it's a loop marker in the output stream
@@ -1478,7 +1516,7 @@ func runPlanAndBuild(cfg *config.Config, tokenStats *stats.TokenStats, logFile i
 	model.SetTmuxStatusBar(tmuxBar)
 	model.SetGitContext(dbCtx.repo, dbCtx.branch)
 	model.SetPlanFile(cfg.PlanFile)
-	model.SetModelInfo(cfg.Model, cfg.Effort)
+	model.SetModelInfo(cfg.Model, config.ResolveEffort(cfg.Effort))
 
 	// Start in planning mode
 	model.SetCurrentMode("Planning")
@@ -1665,9 +1703,7 @@ func processPlanPhase(
 			case "output":
 				parsed := jsonParser.ParseLine(msg.Content)
 				if parsed != nil {
-					if sessionID := jsonParser.GetSessionID(parsed); sessionID != "" {
-						planLoop.SetSessionID(sessionID)
-					}
+					trackSession(planLoop, jsonParser.GetSessionID(parsed), program)
 					handleParsedMessage(parsed, planLoop, jsonParser, tokenStats, msgChan, program, &loopTotalTokens, logFile, &iterEstimate, &subagentCostAccum, &lastResultCost, &iterToolUseCount, &noopStreak, apiBackoff, seenMsgIDs)
 				} else if isAuthenticationText(msg.Content) {
 					if os.Getenv("ANTHROPIC_API_KEY") != "" {
@@ -1773,9 +1809,7 @@ func processBuildPhase(
 			case "output":
 				parsed := jsonParser.ParseLine(msg.Content)
 				if parsed != nil {
-					if sessionID := jsonParser.GetSessionID(parsed); sessionID != "" {
-						buildLoop.SetSessionID(sessionID)
-					}
+					trackSession(buildLoop, jsonParser.GetSessionID(parsed), program)
 					handleParsedMessage(parsed, buildLoop, jsonParser, tokenStats, msgChan, program, &loopTotalTokens, logFile, &iterEstimate, &subagentCostAccum, &lastResultCost, &iterToolUseCount, &noopStreak, apiBackoff, seenMsgIDs)
 				} else if isAuthenticationText(msg.Content) {
 					if os.Getenv("ANTHROPIC_API_KEY") != "" {

--- a/cmd/ralph/main.go
+++ b/cmd/ralph/main.go
@@ -488,12 +488,12 @@ func processLoopOutput(
 	defer close(msgChan)
 
 	loopOutput := claudeLoop.Output()
-	var loopTotalTokens int64       // per-loop token tracking for tmux status bar
-	var iterEstimate float64        // per-iteration estimated cost from token counts
-	var subagentCostAccum float64   // per-iteration accumulated subagent actual costs for reconciliation
-	var lastResultCost float64      // tracks previous result's cumulative total_cost_usd for delta computation
-	var iterToolUseCount int        // per-iteration tool use count for exit loop detection
-	var noopStreak int              // consecutive no-op iterations for exit loop detection
+	var loopTotalTokens int64           // per-loop token tracking for tmux status bar
+	var iterEstimate float64            // per-iteration estimated cost from token counts
+	var subagentCostAccum float64       // per-iteration accumulated subagent actual costs for reconciliation
+	var lastResultCost float64          // tracks previous result's cumulative total_cost_usd for delta computation
+	var iterToolUseCount int            // per-iteration tool use count for exit loop detection
+	var noopStreak int                  // consecutive no-op iterations for exit loop detection
 	seenMsgIDs := make(map[string]bool) // dedup: CLI emits multiple chunks per message ID with identical usage
 	lt := &loopTracker{}
 	apiBackoff := loop.NewBackoff() // exponential backoff for API 529 errors

--- a/cmd/ralph/main.go
+++ b/cmd/ralph/main.go
@@ -500,7 +500,6 @@ func processLoopOutput(
 
 	// Startup budget check — hibernate before first iteration if budget already exceeded
 	if exceeded, hourCost, nextHour := checkCostPacing(dbCtx, maxCostPerHour, claudeLoop); exceeded {
-		program.Send(tui.SendHibernate(nextHour)())
 		msgChan <- tui.Message{
 			Role:    tui.RoleHibernate,
 			Content: fmt.Sprintf("Cost budget exceeded ($%.4f/$%.2f/hr) at startup, pausing until %s", hourCost, maxCostPerHour, nextHour.Format(time.Kitchen)),
@@ -519,7 +518,6 @@ func processLoopOutput(
 		case <-ticker.C:
 			lt.flushDelta(dbCtx, tokenStats)
 			if exceeded, hourCost, nextHour := checkCostPacing(dbCtx, maxCostPerHour, claudeLoop); exceeded {
-				program.Send(tui.SendHibernate(nextHour)())
 				msgChan <- tui.Message{
 					Role:    tui.RoleHibernate,
 					Content: fmt.Sprintf("Cost budget exceeded ($%.4f/$%.2f/hr), pausing until %s", hourCost, maxCostPerHour, nextHour.Format(time.Kitchen)),
@@ -686,7 +684,6 @@ func handleParsedMessage(
 	// Check for rate limit rejection — enter hibernate state
 	if rejected, resetsAt := jsonParser.IsRateLimitRejected(parsed); rejected {
 		claudeLoop.Hibernate(resetsAt)
-		program.Send(tui.SendHibernate(resetsAt)())
 		msgChan <- tui.Message{
 			Role:    tui.RoleHibernate,
 			Content: fmt.Sprintf("Rate limited until %s", resetsAt.Format(time.Kitchen)),
@@ -707,7 +704,6 @@ func handleParsedMessage(
 		}
 		resetsAt := time.Now().Add(backoffDuration)
 		claudeLoop.Hibernate(resetsAt)
-		program.Send(tui.SendHibernate(resetsAt)())
 		msgChan <- tui.Message{
 			Role:    tui.RoleHibernate,
 			Content: fmt.Sprintf("API overloaded (529), retry %d/%d, hibernating %s until %s", retryNum, apiBackoff.MaxRetries(), backoffDuration.Round(time.Second), resetsAt.Format(time.Kitchen)),
@@ -728,7 +724,6 @@ func handleParsedMessage(
 		}
 		resetsAt := time.Now().Add(backoffDuration)
 		claudeLoop.Hibernate(resetsAt)
-		program.Send(tui.SendHibernate(resetsAt)())
 		msgChan <- tui.Message{
 			Role:    tui.RoleHibernate,
 			Content: fmt.Sprintf("API server error (500), retry %d/%d, hibernating %s until %s", retryNum, apiBackoff.MaxRetries(), backoffDuration.Round(time.Second), resetsAt.Format(time.Kitchen)),
@@ -1630,7 +1625,6 @@ func processPlanPhase(
 
 	// Startup budget check — hibernate before first iteration if budget already exceeded
 	if exceeded, hourCost, nextHour := checkCostPacing(dbCtx, maxCostPerHour, planLoop); exceeded {
-		program.Send(tui.SendHibernate(nextHour)())
 		msgChan <- tui.Message{
 			Role:    tui.RoleHibernate,
 			Content: fmt.Sprintf("Cost budget exceeded ($%.4f/$%.2f/hr) at startup, pausing until %s", hourCost, maxCostPerHour, nextHour.Format(time.Kitchen)),
@@ -1649,7 +1643,6 @@ func processPlanPhase(
 		case <-ticker.C:
 			lt.flushDelta(dbCtx, tokenStats)
 			if exceeded, hourCost, nextHour := checkCostPacing(dbCtx, maxCostPerHour, planLoop); exceeded {
-				program.Send(tui.SendHibernate(nextHour)())
 				msgChan <- tui.Message{
 					Role:    tui.RoleHibernate,
 					Content: fmt.Sprintf("Cost budget exceeded ($%.4f/$%.2f/hr), pausing until %s", hourCost, maxCostPerHour, nextHour.Format(time.Kitchen)),
@@ -1736,7 +1729,6 @@ func processBuildPhase(
 
 	// Startup budget check — hibernate before first iteration if budget already exceeded
 	if exceeded, hourCost, nextHour := checkCostPacing(dbCtx, maxCostPerHour, buildLoop); exceeded {
-		program.Send(tui.SendHibernate(nextHour)())
 		msgChan <- tui.Message{
 			Role:    tui.RoleHibernate,
 			Content: fmt.Sprintf("Cost budget exceeded ($%.4f/$%.2f/hr) at startup, pausing until %s", hourCost, maxCostPerHour, nextHour.Format(time.Kitchen)),
@@ -1755,7 +1747,6 @@ func processBuildPhase(
 		case <-ticker.C:
 			lt.flushDelta(dbCtx, tokenStats)
 			if exceeded, hourCost, nextHour := checkCostPacing(dbCtx, maxCostPerHour, buildLoop); exceeded {
-				program.Send(tui.SendHibernate(nextHour)())
 				msgChan <- tui.Message{
 					Role:    tui.RoleHibernate,
 					Content: fmt.Sprintf("Cost budget exceeded ($%.4f/$%.2f/hr), pausing until %s", hourCost, maxCostPerHour, nextHour.Format(time.Kitchen)),

--- a/cmd/ralph/main.go
+++ b/cmd/ralph/main.go
@@ -424,10 +424,7 @@ func main() {
 	model.SetTmuxStatusBar(tmuxBar)
 	model.SetGitContext(dbCtx.repo, dbCtx.branch)
 	model.SetPlanFile(cfg.PlanFile)
-
-	// Parse implementation plan for task counts
-	completedTasks, totalTasks := parseTaskCounts(cfg.PlanFile)
-	model.SetCompletedTasks(completedTasks, totalTasks)
+	model.SetModelInfo(cfg.Model, cfg.Effort)
 
 	// Set current mode for TUI display
 	if cfg.IsPlanMode() {
@@ -772,13 +769,20 @@ func handleParsedMessage(
 				usage.CacheReadInputTokens,
 			)
 			// Estimate cost from token counts and update in real-time
+			msgModel := jsonParser.GetModel(parsed)
 			estimate := stats.EstimateCostFromTokens(
-				jsonParser.GetModel(parsed),
+				msgModel,
 				usage.InputTokens,
 				usage.OutputTokens,
 				usage.CacheCreationInputTokens,
 				usage.CacheReadInputTokens,
 			)
+			// Report the effective model to the Model Details panel. Subagent
+			// messages are skipped — they may run a different model than the
+			// main loop.
+			if msgModel != "" && !jsonParser.IsSubagentMessage(parsed) {
+				program.Send(tui.SendModelUpdate(msgModel)())
+			}
 			tokenStats.AddCost(estimate)
 			*iterEstimate += estimate
 			program.Send(tui.SendStatsUpdate(tokenStats)())
@@ -818,7 +822,12 @@ func handleParsedMessage(
 	// Process message content based on type
 	switch parsed.Type {
 	case parser.MessageTypeSystem:
-		// Skip system messages (as Python version does)
+		// System messages aren't displayed, but the init line names the model
+		// the session actually resolved to — the only source when --model was
+		// not passed. Feed it to the Model Details panel before dropping it.
+		if mdl := jsonParser.GetModel(parsed); mdl != "" && !jsonParser.IsSubagentMessage(parsed) {
+			program.Send(tui.SendModelUpdate(mdl)())
+		}
 		return
 
 	case parser.MessageTypeAssistant:
@@ -840,7 +849,7 @@ func handleParsedMessage(
 			fmt.Fprintf(logFile, "[thinking] %s\n\n", content.Thinking)
 		}
 
-		// Display text content and scan for task references
+		// Display text content
 		for _, text := range content.TextContent {
 			if text != "" {
 				msgChan <- tui.Message{
@@ -848,14 +857,6 @@ func handleParsedMessage(
 					Content: text,
 				}
 				fmt.Fprintf(logFile, "[assistant] %s\n\n", text)
-				// Detect IMPLEMENTATION_PLAN.md task references
-				if ref := jsonParser.ExtractTaskReference(text); ref != nil {
-					taskLabel := fmt.Sprintf("#%d", ref.Number)
-					if ref.Description != "" {
-						taskLabel = fmt.Sprintf("#%d %s", ref.Number, ref.Description)
-					}
-					program.Send(tui.SendTaskUpdate(taskLabel)())
-				}
 			}
 		}
 
@@ -888,8 +889,7 @@ func handleParsedMessage(
 
 	case parser.MessageTypeUser:
 		// Skip tool result content in TUI mode (file dumps are too verbose).
-		// Flip the matching tool row to completed/failed, and still scan for
-		// task references in the results.
+		// Flip the matching tool row to completed/failed.
 		content := jsonParser.ExtractContent(parsed)
 		for _, toolResult := range content.ToolResults {
 			if toolResult.ToolUseID != "" {
@@ -898,15 +898,6 @@ func handleParsedMessage(
 					status = parser.ToolStatusFailed
 				}
 				program.Send(tui.SendToolStatusUpdate(toolResult.ToolUseID, string(status))())
-			}
-			if toolResult.Content != "" {
-				if ref := jsonParser.ExtractTaskReference(toolResult.Content); ref != nil {
-					taskLabel := fmt.Sprintf("#%d", ref.Number)
-					if ref.Description != "" {
-						taskLabel = fmt.Sprintf("#%d %s", ref.Number, ref.Description)
-					}
-					program.Send(tui.SendTaskUpdate(taskLabel)())
-				}
 			}
 		}
 
@@ -1492,10 +1483,7 @@ func runPlanAndBuild(cfg *config.Config, tokenStats *stats.TokenStats, logFile i
 	model.SetTmuxStatusBar(tmuxBar)
 	model.SetGitContext(dbCtx.repo, dbCtx.branch)
 	model.SetPlanFile(cfg.PlanFile)
-
-	// Parse implementation plan for task counts
-	completedTasks, totalTasks := parseTaskCounts(cfg.PlanFile)
-	model.SetCompletedTasks(completedTasks, totalTasks)
+	model.SetModelInfo(cfg.Model, cfg.Effort)
 
 	// Start in planning mode
 	model.SetCurrentMode("Planning")
@@ -1846,24 +1834,4 @@ func isNewLoopStart(content string) bool {
 // (the iteration is being retried after a 529/500 hibernate, not a fresh start).
 func isRetryLoopStart(content string) bool {
 	return strings.Contains(content, "LOOP") && strings.Contains(content, "RETRY")
-}
-
-// parseTaskCounts reads an IMPLEMENTATION_PLAN.md file and returns the number of
-// completed (DONE) tasks and the total number of tasks.
-func parseTaskCounts(filepath string) (completed, total int) {
-	data, err := os.ReadFile(filepath)
-	if err != nil {
-		return 0, 0
-	}
-
-	for _, line := range strings.Split(string(data), "\n") {
-		trimmed := strings.TrimSpace(line)
-		if strings.HasPrefix(trimmed, "## TASK ") {
-			total++
-		}
-		if strings.Contains(trimmed, "**Status: DONE**") || strings.Contains(trimmed, "**Status: NOT NEEDED**") {
-			completed++
-		}
-	}
-	return completed, total
 }

--- a/cmd/ralph/main_test.go
+++ b/cmd/ralph/main_test.go
@@ -694,3 +694,30 @@ func TestModelUpdateSkipsSubagentMessages(t *testing.T) {
 		t.Errorf("last reported model = %q, want %q (subagent model must not win)", lastReported, "claude-opus-4-8")
 	}
 }
+
+// TestTrackSessionRecordsSessionID tests that trackSession keeps the loop's
+// session ID up to date for --resume support, which the three call sites in the
+// TUI message pumps depend on.
+func TestTrackSessionRecordsSessionID(t *testing.T) {
+	claudeLoop := loop.New(loop.Config{Iterations: 5, Prompt: "test"})
+
+	// A nil program means no TUI to refine the effort level for; the session
+	// bookkeeping still has to happen.
+	trackSession(claudeLoop, "a50b7b11-7b8d-44a7-bdf5-0433d84f3fb1", nil)
+	if got := claudeLoop.GetSessionID(); got != "a50b7b11-7b8d-44a7-bdf5-0433d84f3fb1" {
+		t.Errorf("GetSessionID = %q, want the tracked session", got)
+	}
+
+	// Most stream lines carry no session ID; those must not wipe the stored one
+	// or the next iteration loses its --resume target.
+	trackSession(claudeLoop, "", nil)
+	if got := claudeLoop.GetSessionID(); got != "a50b7b11-7b8d-44a7-bdf5-0433d84f3fb1" {
+		t.Errorf("GetSessionID = %q after an empty ID, want the previously tracked session", got)
+	}
+
+	// A new session replaces it.
+	trackSession(claudeLoop, "b61c8c22-8c9e-4bf8-cfe6-1544981e4c62", nil)
+	if got := claudeLoop.GetSessionID(); got != "b61c8c22-8c9e-4bf8-cfe6-1544981e4c62" {
+		t.Errorf("GetSessionID = %q, want the newest session", got)
+	}
+}

--- a/cmd/ralph/main_test.go
+++ b/cmd/ralph/main_test.go
@@ -15,187 +15,6 @@ import (
 	"github.com/cloudosai/ralph-go/internal/stats"
 )
 
-func TestParseTaskCountsNoFile(t *testing.T) {
-	completed, total := parseTaskCounts("/nonexistent/path/IMPLEMENTATION_PLAN.md")
-	if completed != 0 || total != 0 {
-		t.Errorf("expected (0, 0) for missing file, got (%d, %d)", completed, total)
-	}
-}
-
-func TestParseTaskCountsEmptyFile(t *testing.T) {
-	tmpDir := t.TempDir()
-	path := filepath.Join(tmpDir, "IMPLEMENTATION_PLAN.md")
-	os.WriteFile(path, []byte(""), 0644)
-
-	completed, total := parseTaskCounts(path)
-	if completed != 0 || total != 0 {
-		t.Errorf("expected (0, 0) for empty file, got (%d, %d)", completed, total)
-	}
-}
-
-func TestParseTaskCountsSingleTaskTodo(t *testing.T) {
-	tmpDir := t.TempDir()
-	path := filepath.Join(tmpDir, "IMPLEMENTATION_PLAN.md")
-	content := `# Implementation Plan
-
-## TASK 1: Add feature X
-**Priority: HIGH**
-**Status: TODO**
-`
-	os.WriteFile(path, []byte(content), 0644)
-
-	completed, total := parseTaskCounts(path)
-	if total != 1 {
-		t.Errorf("expected total=1, got %d", total)
-	}
-	if completed != 0 {
-		t.Errorf("expected completed=0, got %d", completed)
-	}
-}
-
-func TestParseTaskCountsSingleTaskDone(t *testing.T) {
-	tmpDir := t.TempDir()
-	path := filepath.Join(tmpDir, "IMPLEMENTATION_PLAN.md")
-	content := `# Implementation Plan
-
-## TASK 1: Add feature X
-**Priority: HIGH**
-**Status: DONE**
-`
-	os.WriteFile(path, []byte(content), 0644)
-
-	completed, total := parseTaskCounts(path)
-	if total != 1 {
-		t.Errorf("expected total=1, got %d", total)
-	}
-	if completed != 1 {
-		t.Errorf("expected completed=1, got %d", completed)
-	}
-}
-
-func TestParseTaskCountsNotNeeded(t *testing.T) {
-	tmpDir := t.TempDir()
-	path := filepath.Join(tmpDir, "IMPLEMENTATION_PLAN.md")
-	content := `# Implementation Plan
-
-## TASK 1: Deprecated feature
-**Status: NOT NEEDED**
-`
-	os.WriteFile(path, []byte(content), 0644)
-
-	completed, total := parseTaskCounts(path)
-	if total != 1 {
-		t.Errorf("expected total=1, got %d", total)
-	}
-	if completed != 1 {
-		t.Errorf("expected completed=1, got %d", completed)
-	}
-}
-
-func TestParseTaskCountsMultipleTasks(t *testing.T) {
-	tmpDir := t.TempDir()
-	path := filepath.Join(tmpDir, "IMPLEMENTATION_PLAN.md")
-	content := `# Implementation Plan
-
-## TASK 1: First feature
-**Status: DONE**
-
-## TASK 2: Second feature
-**Status: IN PROGRESS**
-
-## TASK 3: Third feature
-**Status: TODO**
-
-## TASK 4: Fourth feature
-**Status: DONE**
-
-## TASK 5: Fifth feature
-**Status: NOT NEEDED**
-`
-	os.WriteFile(path, []byte(content), 0644)
-
-	completed, total := parseTaskCounts(path)
-	if total != 5 {
-		t.Errorf("expected total=5, got %d", total)
-	}
-	if completed != 3 {
-		t.Errorf("expected completed=3 (2 DONE + 1 NOT NEEDED), got %d", completed)
-	}
-}
-
-func TestParseTaskCountsNoTaskHeaders(t *testing.T) {
-	tmpDir := t.TempDir()
-	path := filepath.Join(tmpDir, "IMPLEMENTATION_PLAN.md")
-	content := `# Implementation Plan
-
-Some general notes about the project.
-
-**Status: DONE**
-`
-	os.WriteFile(path, []byte(content), 0644)
-
-	completed, total := parseTaskCounts(path)
-	if total != 0 {
-		t.Errorf("expected total=0 (no ## TASK headers), got %d", total)
-	}
-	// Status line without a TASK header still counts as completed
-	if completed != 1 {
-		t.Errorf("expected completed=1 (status line exists), got %d", completed)
-	}
-}
-
-func TestParseTaskCountsStatusOnSameLineAsHeader(t *testing.T) {
-	tmpDir := t.TempDir()
-	path := filepath.Join(tmpDir, "IMPLEMENTATION_PLAN.md")
-	content := `## TASK 1: Feature — **Status: DONE**
-## TASK 2: Other feature
-**Status: TODO**
-`
-	os.WriteFile(path, []byte(content), 0644)
-
-	completed, total := parseTaskCounts(path)
-	if total != 2 {
-		t.Errorf("expected total=2, got %d", total)
-	}
-	if completed != 1 {
-		t.Errorf("expected completed=1, got %d", completed)
-	}
-}
-
-func TestParseTaskCountsReflectsFileChanges(t *testing.T) {
-	// Verifies that repeated calls to parseTaskCounts pick up file modifications,
-	// which is the basis for live recount at iteration boundaries.
-	tmpDir := t.TempDir()
-	path := filepath.Join(tmpDir, "IMPLEMENTATION_PLAN.md")
-
-	// Initial: 1 done out of 3
-	initial := "## TASK 1\n**Status: DONE**\n## TASK 2\n**Status: TODO**\n## TASK 3\n**Status: TODO**\n"
-	os.WriteFile(path, []byte(initial), 0644)
-
-	completed, total := parseTaskCounts(path)
-	if completed != 1 || total != 3 {
-		t.Errorf("initial: expected 1/3, got %d/%d", completed, total)
-	}
-
-	// Simulate Claude marking task 2 as DONE during an iteration
-	updated := "## TASK 1\n**Status: DONE**\n## TASK 2\n**Status: DONE**\n## TASK 3\n**Status: TODO**\n"
-	os.WriteFile(path, []byte(updated), 0644)
-
-	completed, total = parseTaskCounts(path)
-	if completed != 2 || total != 3 {
-		t.Errorf("after update: expected 2/3, got %d/%d", completed, total)
-	}
-
-	// Simulate adding a new task during the session
-	expanded := updated + "## TASK 4\n**Status: TODO**\n"
-	os.WriteFile(path, []byte(expanded), 0644)
-
-	completed, total = parseTaskCounts(path)
-	if completed != 2 || total != 4 {
-		t.Errorf("after expansion: expected 2/4, got %d/%d", completed, total)
-	}
-}
-
 func TestCheckCostPacingDisabled(t *testing.T) {
 	// maxCostPerHour=0 means disabled — should be a no-op
 	exceeded, hourCost, nextHour := checkCostPacing(&dbContext{}, 0, nil)
@@ -783,5 +602,95 @@ func TestStartNewLoopNotCalledOnHibernateRetry(t *testing.T) {
 	}
 	if startNewLoopCallCount != 2 {
 		t.Errorf("expected startNewLoop call count=2 after second fresh loop, got %d", startNewLoopCallCount)
+	}
+}
+
+// shouldSendModelUpdate mirrors the gate handleParsedMessage applies at both of
+// its model-reporting call sites (the assistant-usage branch and the system
+// branch):
+//
+//	msgModel := jsonParser.GetModel(parsed)
+//	if msgModel != "" && !jsonParser.IsSubagentMessage(parsed) { ...send model update... }
+func shouldSendModelUpdate(p *parser.Parser, msg *parser.ParsedMessage) (string, bool) {
+	model := p.GetModel(msg)
+	return model, model != "" && !p.IsSubagentMessage(msg)
+}
+
+// TestModelUpdateSkipsSubagentMessages locks in the Model Details panel's source
+// of truth: the effective model is reported from main-loop messages only. A
+// subagent may run a different model than the main loop, so its messages must
+// not overwrite the panel.
+func TestModelUpdateSkipsSubagentMessages(t *testing.T) {
+	jsonParser := parser.NewParser()
+
+	tests := []struct {
+		name      string
+		line      string
+		wantModel string
+		wantSend  bool
+	}{
+		{
+			// The system init line carries "model" at the top level and is the
+			// only source of the effective model when --model was not passed.
+			name:      "system init line",
+			line:      `{"type":"system","subtype":"init","session_id":"6374d5b9-d485-4579-80c9-d31f1f87c926","model":"claude-sonnet-4-6"}`,
+			wantModel: "claude-sonnet-4-6",
+			wantSend:  true,
+		},
+		{
+			// Main-loop assistant messages carry the model under "message".
+			name:      "main-loop assistant message",
+			line:      `{"type":"assistant","parent_tool_use_id":null,"message":{"id":"msg_01Main","type":"message","role":"assistant","model":"claude-opus-4-8","content":[{"type":"text","text":"working"}]}}`,
+			wantModel: "claude-opus-4-8",
+			wantSend:  true,
+		},
+		{
+			// Non-null parent_tool_use_id marks a subagent message: the model is
+			// still readable, but the gate must reject it.
+			name:      "subagent assistant message",
+			line:      `{"type":"assistant","parent_tool_use_id":"toolu_01SubagentTask","message":{"id":"msg_01Sub","type":"message","role":"assistant","model":"claude-haiku-4-5","content":[{"type":"text","text":"subagent working"}]}}`,
+			wantModel: "claude-haiku-4-5",
+			wantSend:  false,
+		},
+		{
+			// No model anywhere → nothing to report.
+			name:      "main-loop assistant message without a model",
+			line:      `{"type":"assistant","parent_tool_use_id":null,"message":{"id":"msg_01NoModel","type":"message","role":"assistant","content":[{"type":"text","text":"no model field"}]}}`,
+			wantModel: "",
+			wantSend:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			parsed := jsonParser.ParseLine(tt.line)
+			if parsed == nil {
+				t.Fatalf("ParseLine returned nil for %q", tt.line)
+			}
+			model, send := shouldSendModelUpdate(jsonParser, parsed)
+			if model != tt.wantModel {
+				t.Errorf("GetModel = %q, want %q", model, tt.wantModel)
+			}
+			if send != tt.wantSend {
+				t.Errorf("model-update gate = %v, want %v", send, tt.wantSend)
+			}
+		})
+	}
+
+	// Replay the lines in stream order: the last model that passes the gate is
+	// what the panel ends up showing, and it must be the main loop's model even
+	// though a subagent message with a different model arrived afterwards.
+	lastReported := ""
+	for _, tt := range tests {
+		parsed := jsonParser.ParseLine(tt.line)
+		if parsed == nil {
+			t.Fatalf("ParseLine returned nil for %q", tt.line)
+		}
+		if model, send := shouldSendModelUpdate(jsonParser, parsed); send {
+			lastReported = model
+		}
+	}
+	if lastReported != "claude-opus-4-8" {
+		t.Errorf("last reported model = %q, want %q (subagent model must not win)", lastReported, "claude-opus-4-8")
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ const (
 )
 
 // Version is set at build time via -ldflags
-var Version = "v2026.7.3"
+var Version = "v2026.8.8"
 
 // DefaultPlanFile is the default implementation plan filename
 const DefaultPlanFile = "IMPLEMENTATION_PLAN.md"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,9 +35,9 @@ type Config struct {
 	ShowPrompt       bool
 	ShowVersion      bool
 	NoTmux           bool
-	CLI             bool
-	MaxCostPerHour  float64 // maximum USD cost per rolling hour (0 = no limit)
-	Subcommand      string  // "plan", "build", "plan-and-build", "autoresearch", or "" (default: build mode)
+	CLI              bool
+	MaxCostPerHour   float64 // maximum USD cost per rolling hour (0 = no limit)
+	Subcommand       string  // "plan", "build", "plan-and-build", "autoresearch", or "" (default: build mode)
 }
 
 // NewConfig returns a new Config with default values

--- a/internal/config/effort.go
+++ b/internal/config/effort.go
@@ -1,0 +1,137 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// claudeSettings is the subset of a .claude/settings*.json file Ralph reads.
+type claudeSettings struct {
+	EffortLevel string `json:"effortLevel"`
+}
+
+// transcriptRecord is the subset of a session transcript record Ralph reads.
+type transcriptRecord struct {
+	Effort string `json:"effort"`
+}
+
+// effortSettingsPaths returns the settings files that can define an effort
+// level, highest precedence first: project-local, then project-shared, then
+// user-global — the order the claude CLI itself resolves them in. Project paths
+// are relative to the working directory, which is where Ralph runs claude.
+//
+// Enterprise managed settings are deliberately not consulted: they outrank even
+// --effort, so a machine under managed policy can run at a level neither this
+// function nor Ralph's own flag decides.
+func effortSettingsPaths() []string {
+	paths := []string{
+		filepath.Join(".claude", "settings.local.json"),
+		filepath.Join(".claude", "settings.json"),
+	}
+	if home, err := os.UserHomeDir(); err == nil {
+		paths = append(paths, filepath.Join(home, ".claude", "settings.json"))
+	}
+	return paths
+}
+
+// ResolveEffort reports the effort level the claude CLI will actually run at,
+// for display only — the value passed to `claude --effort` stays Config.Effort,
+// so resolving here never changes what the loop executes.
+//
+// A non-empty --effort wins outright, since Ralph puts it on the command line.
+// Otherwise the CLI falls back to `effortLevel` in its settings chain, which
+// Ralph has to read itself: unlike the model, which the stream reports on the
+// system/init line, the effort level never appears in the stream-json output,
+// so these files are the only source. Returns "" when nothing configures one
+// and the CLI picks for itself.
+func ResolveEffort(flagEffort string) string {
+	if flagEffort != "" {
+		return flagEffort
+	}
+	for _, path := range effortSettingsPaths() {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		var settings claudeSettings
+		if err := json.Unmarshal(data, &settings); err != nil {
+			// A malformed or half-written settings file is not fatal; the rest
+			// of the chain still applies.
+			continue
+		}
+		if settings.EffortLevel != "" {
+			return settings.EffortLevel
+		}
+	}
+	return ""
+}
+
+// isSessionID reports whether id is shaped like the UUID the claude CLI hands
+// out, which TranscriptEffort interpolates into a glob and a path. Rejecting
+// anything else keeps a surprising session id out of both.
+func isSessionID(id string) bool {
+	if id == "" {
+		return false
+	}
+	for _, r := range id {
+		switch {
+		case r >= '0' && r <= '9', r >= 'a' && r <= 'f', r >= 'A' && r <= 'F', r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// TranscriptEffort reports the effort level the claude CLI itself recorded for
+// a session, or "" if it cannot be determined (yet).
+//
+// This is ground truth where ResolveEffort is only a good guess: the CLI writes
+// the level it actually resolved onto every assistant record of the session
+// transcript, so it accounts for precedence Ralph does not reimplement —
+// notably enterprise managed settings, which outrank even --effort. The cost is
+// a dependency on an undocumented internal file format, so every failure here
+// is silent and simply leaves the resolved-from-settings value in place.
+//
+// It returns "" until the CLI has written its first assistant record, which
+// lands a few seconds into an iteration; callers are expected to retry.
+func TranscriptEffort(sessionID string) string {
+	if !isSessionID(sessionID) {
+		return ""
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	// Session IDs are unique, so globbing across the project directories finds
+	// the transcript without reproducing the CLI's cwd→directory-name mangling.
+	matches, err := filepath.Glob(filepath.Join(home, ".claude", "projects", "*", sessionID+".jsonl"))
+	if err != nil || len(matches) == 0 {
+		return ""
+	}
+	file, err := os.Open(matches[0])
+	if err != nil {
+		return ""
+	}
+	defer file.Close()
+
+	// Records are newline-delimited JSON, but a single one can be megabytes
+	// (a large tool result), so decode the file as a stream of values rather
+	// than scanning it by line.
+	//
+	// The last record wins: a --resume'd session keeps the earlier iterations'
+	// records in the same file, and the newest is the one in force.
+	var effort string
+	decoder := json.NewDecoder(file)
+	for {
+		var record transcriptRecord
+		if err := decoder.Decode(&record); err != nil {
+			break // EOF, or a half-written trailing record — keep what we have.
+		}
+		if record.Effort != "" {
+			effort = record.Effort
+		}
+	}
+	return effort
+}

--- a/internal/loop/backoff.go
+++ b/internal/loop/backoff.go
@@ -18,11 +18,11 @@ const (
 // Backoff tracks exponential backoff state for API 529 (overloaded) errors.
 // It is safe for concurrent use.
 type Backoff struct {
-	mu             sync.Mutex
-	initialBackoff time.Duration
-	maxBackoff     time.Duration
-	maxRetries     int
-	jitterFraction float64
+	mu              sync.Mutex
+	initialBackoff  time.Duration
+	maxBackoff      time.Duration
+	maxRetries      int
+	jitterFraction  float64
 	consecutiveHits int
 }
 

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -375,10 +375,9 @@ func (p *Parser) ExtractContent(msg *ParsedMessage) *ParsedContent {
 					inputJSON = string(jsonBytes)
 				}
 			}
-			// Truncate to 150 characters like Python version
-			if len(inputJSON) > 150 {
-				inputJSON = inputJSON[:150]
-			}
+			// Keep only a short preview of the input; truncate counts runes so
+			// multibyte UTF-8 is never split mid-rune.
+			inputJSON = truncate(inputJSON, 150)
 			location := ExtractFilePathFromInput(item.Input)
 			kind := ClassifyToolKind(item.Name)
 			content.ToolUses = append(content.ToolUses, ToolUse{
@@ -611,10 +610,7 @@ func ExtractFilePathFromInput(input map[string]interface{}) string {
 	}
 	// Try command (Bash) - truncate to first 50 chars
 	if cmd, ok := input["command"].(string); ok && cmd != "" {
-		if len(cmd) > 50 {
-			return cmd[:50] + "..."
-		}
-		return cmd
+		return truncate(cmd, 50)
 	}
 	// Try description (Task)
 	if desc, ok := input["description"].(string); ok && desc != "" {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -172,15 +172,15 @@ type RateLimitInfo struct {
 
 // ContentItem represents a single content item in a message
 type ContentItem struct {
-	Type           ContentType            `json:"type"`
-	Text           string                 `json:"text,omitempty"`
-	ID             string                 `json:"id,omitempty"`          // Tool use ID for tool_use
-	Name           string                 `json:"name,omitempty"`        // Tool name for tool_use
-	Input          map[string]interface{} `json:"input,omitempty"`       // Tool input for tool_use
-	ToolUseID      string                 `json:"tool_use_id,omitempty"` // Tool use ID for tool_result
-	Content        interface{}            `json:"content,omitempty"`     // Tool result content
-	ThinkingText   string                 `json:"thinking,omitempty"`    // Thinking content for thinking items
-	IsError        bool                   `json:"is_error,omitempty"`    // True for failed tool_result
+	Type         ContentType            `json:"type"`
+	Text         string                 `json:"text,omitempty"`
+	ID           string                 `json:"id,omitempty"`          // Tool use ID for tool_use
+	Name         string                 `json:"name,omitempty"`        // Tool name for tool_use
+	Input        map[string]interface{} `json:"input,omitempty"`       // Tool input for tool_use
+	ToolUseID    string                 `json:"tool_use_id,omitempty"` // Tool use ID for tool_result
+	Content      interface{}            `json:"content,omitempty"`     // Tool result content
+	ThinkingText string                 `json:"thinking,omitempty"`    // Thinking content for thinking items
+	IsError      bool                   `json:"is_error,omitempty"`    // True for failed tool_result
 }
 
 // InnerMessage represents the message field within an assistant/user message
@@ -193,17 +193,17 @@ type InnerMessage struct {
 
 // ParsedMessage represents a parsed Claude message
 type ParsedMessage struct {
-	Type            MessageType    `json:"type"`
-	SessionID       string         `json:"session_id,omitempty"`
-	Model           string         `json:"model,omitempty"` // top-level model (system init messages)
-	Message         *InnerMessage  `json:"message,omitempty"`
-	TotalCostUSD    float64        `json:"total_cost_usd,omitempty"`
-	CostUSD         float64        `json:"cost_usd,omitempty"`
-	ParentToolUseID *string        `json:"parent_tool_use_id,omitempty"`
-	IsError         bool              `json:"is_error,omitempty"`
-	ErrorRaw        json.RawMessage   `json:"error,omitempty"`
-	RateLimitInfo   *RateLimitInfo    `json:"rate_limit_info,omitempty"`
-	RawJSON         string         `json:"-"` // Original JSON for debugging
+	Type            MessageType     `json:"type"`
+	SessionID       string          `json:"session_id,omitempty"`
+	Model           string          `json:"model,omitempty"` // top-level model (system init messages)
+	Message         *InnerMessage   `json:"message,omitempty"`
+	TotalCostUSD    float64         `json:"total_cost_usd,omitempty"`
+	CostUSD         float64         `json:"cost_usd,omitempty"`
+	ParentToolUseID *string         `json:"parent_tool_use_id,omitempty"`
+	IsError         bool            `json:"is_error,omitempty"`
+	ErrorRaw        json.RawMessage `json:"error,omitempty"`
+	RateLimitInfo   *RateLimitInfo  `json:"rate_limit_info,omitempty"`
+	RawJSON         string          `json:"-"` // Original JSON for debugging
 }
 
 // LoopMarker represents a loop marker extracted from output

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -195,6 +195,7 @@ type InnerMessage struct {
 type ParsedMessage struct {
 	Type            MessageType    `json:"type"`
 	SessionID       string         `json:"session_id,omitempty"`
+	Model           string         `json:"model,omitempty"` // top-level model (system init messages)
 	Message         *InnerMessage  `json:"message,omitempty"`
 	TotalCostUSD    float64        `json:"total_cost_usd,omitempty"`
 	CostUSD         float64        `json:"cost_usd,omitempty"`
@@ -243,19 +244,11 @@ type ToolResult struct {
 	IsError   bool   // True if the tool call failed
 }
 
-// TaskReference represents a detected IMPLEMENTATION_PLAN.md task reference
-type TaskReference struct {
-	Number      int
-	Description string // Optional description (e.g., "Track IMPLEMENTATION_PLAN.md Phase/Task")
-}
-
 // Parser handles parsing of Claude's stream-json output
 type Parser struct {
 	systemReminderRegex *regexp.Regexp
 	loopMarkerRegex     *regexp.Regexp
 	thinkingRegex       *regexp.Regexp
-	taskRegex           *regexp.Regexp
-	taskWithDescRegex   *regexp.Regexp
 }
 
 // NewParser creates a new Parser instance
@@ -264,8 +257,6 @@ func NewParser() *Parser {
 		systemReminderRegex: regexp.MustCompile(`(?s)<system-reminder>.*?</system-reminder>`),
 		loopMarkerRegex:     regexp.MustCompile(`LOOP (\d+)/(\d+)`),
 		thinkingRegex:       regexp.MustCompile(`(?s)<thinking>(.*?)</thinking>`),
-		taskRegex:           regexp.MustCompile(`(?i)TASK\s+(\d+)`),
-		taskWithDescRegex:   regexp.MustCompile(`(?i)TASK\s+(\d+)\s*:\s*([^\[\n]+)`),
 	}
 }
 
@@ -451,12 +442,17 @@ func (p *Parser) GetUsage(msg *ParsedMessage) *Usage {
 }
 
 // GetModel returns the model identifier from a message (e.g. "claude-opus-4-8"),
-// or empty string if not present.
+// or empty string if not present. Assistant messages carry it under "message";
+// the system init line carries it at the top level, so both are checked — the
+// init line is what tells us the effective model when --model was not passed.
 func (p *Parser) GetModel(msg *ParsedMessage) string {
-	if msg == nil || msg.Message == nil {
+	if msg == nil {
 		return ""
 	}
-	return msg.Message.Model
+	if msg.Message != nil && msg.Message.Model != "" {
+		return msg.Message.Model
+	}
+	return msg.Model
 }
 
 // GetCost extracts the total cost from a result message
@@ -669,36 +665,4 @@ func normalizePlanStatus(s string) PlanItemStatus {
 	default:
 		return PlanPending
 	}
-}
-
-// ExtractTaskReference scans text for references to IMPLEMENTATION_PLAN.md tasks
-// (e.g., "TASK 6", "Task 3: Some Description"). Returns the last match found,
-// or nil if no task reference is detected.
-func (p *Parser) ExtractTaskReference(text string) *TaskReference {
-	// Try the more specific pattern first (TASK N: description)
-	descMatches := p.taskWithDescRegex.FindAllStringSubmatch(text, -1)
-	if len(descMatches) > 0 {
-		last := descMatches[len(descMatches)-1]
-		num := parseInt(last[1])
-		if num > 0 {
-			return &TaskReference{
-				Number:      num,
-				Description: strings.TrimSpace(last[2]),
-			}
-		}
-	}
-
-	// Fall back to simple pattern (TASK N)
-	matches := p.taskRegex.FindAllStringSubmatch(text, -1)
-	if len(matches) > 0 {
-		last := matches[len(matches)-1]
-		num := parseInt(last[1])
-		if num > 0 {
-			return &TaskReference{
-				Number: num,
-			}
-		}
-	}
-
-	return nil
 }

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -83,19 +83,38 @@ var (
 // was made model-aware.
 var DefaultPricing = pricingSonnet
 
+// ModelTier returns the short tier name for a Claude model identifier
+// ("claude-opus-4-8" → "opus"), matching by substring so new point releases
+// within a tier need no code change. Returns "" when the identifier is empty
+// or belongs to no known tier.
+func ModelTier(model string) string {
+	m := strings.ToLower(model)
+	switch {
+	case strings.Contains(m, "opus"):
+		return "opus"
+	case strings.Contains(m, "sonnet"):
+		return "sonnet"
+	case strings.Contains(m, "haiku"):
+		return "haiku"
+	case strings.Contains(m, "fable"):
+		return "fable"
+	default:
+		return ""
+	}
+}
+
 // PricingForModel returns the price set for a Claude model identifier (e.g.
 // "claude-opus-4-8"), matching by tier substring. Empty or unrecognized
 // identifiers fall back to DefaultPricing.
 func PricingForModel(model string) ModelPricing {
-	m := strings.ToLower(model)
-	switch {
-	case strings.Contains(m, "opus"):
+	switch ModelTier(model) {
+	case "opus":
 		return pricingOpus
-	case strings.Contains(m, "sonnet"):
+	case "sonnet":
 		return pricingSonnet
-	case strings.Contains(m, "haiku"):
+	case "haiku":
 		return pricingHaiku
-	case strings.Contains(m, "fable"):
+	case "fable":
 		return pricingFable
 	default:
 		return DefaultPricing

--- a/internal/stats/stats.go
+++ b/internal/stats/stats.go
@@ -197,7 +197,6 @@ func FormatTokens(count int64) string {
 	}
 }
 
-
 // GenerateSessionID returns a 6-char lowercase hex string from crypto/rand.
 func GenerateSessionID() (string, error) {
 	b := make([]byte, 3)
@@ -408,17 +407,17 @@ func ProjectKey(owner, repo string) string {
 
 // CheckpointParams holds parameters for a checkpoint row insert.
 type CheckpointParams struct {
-	LoopID            string
-	SessionID         string
-	Owner             string
-	Repo              string
-	Branch            string
-	DeltaCost         float64
-	DeltaInputTokens  int64
-	DeltaOutputTokens int64
+	LoopID             string
+	SessionID          string
+	Owner              string
+	Repo               string
+	Branch             string
+	DeltaCost          float64
+	DeltaInputTokens   int64
+	DeltaOutputTokens  int64
 	DeltaCacheCreation int64
-	DeltaCacheRead    int64
-	Timestamp         string
+	DeltaCacheRead     int64
+	Timestamp          string
 }
 
 // FlushCheckpoint inserts a checkpoint row into the database.
@@ -562,4 +561,3 @@ func QueryRollingWakeTime(db *sql.DB, owner, repo string, limit float64) (time.T
 	// Fallback: no single row's aging-out is sufficient
 	return time.Now().UTC().Add(60 * time.Minute), nil
 }
-

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"syscall"
 )
 
@@ -63,9 +64,20 @@ func (s *StatusBar) Restore() {
 }
 
 // FormatStatusRight builds the tmux status bar content string.
-func FormatStatusRight(repo, branch, loopDisplay, timeDisplay string) string {
-	return fmt.Sprintf("[%s | %s | loop: %s, uptime: %s]",
-		repo, branch, loopDisplay, timeDisplay)
+//
+// tokenDisplay and timeDisplay describe the CURRENT loop iteration, not the
+// cumulative session — see Model.updateTmuxStatusBar. Either may be empty (the
+// hibernate variant supplies neither), in which case the field is omitted
+// entirely rather than rendered as a dangling label.
+func FormatStatusRight(repo, branch, loopDisplay, tokenDisplay, timeDisplay string) string {
+	fields := []string{"loop: " + loopDisplay}
+	if tokenDisplay != "" {
+		fields = append(fields, "tokens: "+tokenDisplay)
+	}
+	if timeDisplay != "" {
+		fields = append(fields, "elapsed: "+timeDisplay)
+	}
+	return fmt.Sprintf("[%s | %s | %s]", repo, branch, strings.Join(fields, ", "))
 }
 
 // IsInsideTmux returns true if the current process is running inside a tmux session.

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -1285,8 +1285,9 @@ func (m Model) renderFooter() string {
 	)
 }
 
-// updateTmuxStatusBar updates the tmux status-right bar with current loop stats
-// (spec: stats should be about the current loop, not cumulative)
+// updateTmuxStatusBar updates the tmux status-right bar with stats for the
+// current loop iteration (spec: stats should be about the current loop, not
+// cumulative). Called once per tick.
 func (m Model) updateTmuxStatusBar() {
 	if m.tmuxBar == nil || !m.tmuxBar.IsActive() {
 		return
@@ -1301,7 +1302,7 @@ func (m Model) updateTmuxStatusBar() {
 		mins := int(remaining.Minutes())
 		secs := int(remaining.Seconds()) % 60
 		hibernateDisplay := fmt.Sprintf("RATE LIMITED 💤 %02d:%02d", mins, secs)
-		m.tmuxBar.Update(tmux.FormatStatusRight(m.repoName, m.branchName, hibernateDisplay, ""))
+		m.tmuxBar.Update(tmux.FormatStatusRight(m.repoName, m.branchName, hibernateDisplay, "", ""))
 		return
 	}
 
@@ -1310,14 +1311,18 @@ func (m Model) updateTmuxStatusBar() {
 		loopDisplay = fmt.Sprintf("%d/%d", m.currentLoop, m.totalLoops)
 	}
 
-	// Total session uptime
-	elapsed := m.getElapsed()
+	// Elapsed time and tokens for the CURRENT loop iteration, not the whole
+	// session: both reset on loopStartedMsg. The cumulative session figures stay
+	// in the TUI footer ("Total Time" / "Total Tokens"), so the two surfaces
+	// complement each other instead of duplicating.
+	elapsed := m.getLoopElapsed()
 	hours := int(elapsed.Hours())
 	minutes := int(elapsed.Minutes()) % 60
 	seconds := int(elapsed.Seconds()) % 60
 	timeDisplay := fmt.Sprintf("%02d:%02d:%02d", hours, minutes, seconds)
+	tokenDisplay := stats.FormatTokens(m.loopTotalTokens)
 
-	m.tmuxBar.Update(tmux.FormatStatusRight(m.repoName, m.branchName, loopDisplay, timeDisplay))
+	m.tmuxBar.Update(tmux.FormatStatusRight(m.repoName, m.branchName, loopDisplay, tokenDisplay, timeDisplay))
 }
 
 // SendMessage is a helper command to send a message to the TUI

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -57,7 +57,7 @@ var (
 	colorGreen     = lipgloss.Color("#9ECE6A")
 	colorDimGray   = lipgloss.Color("#565F89")
 	colorLightGray = lipgloss.Color("#C0CAF5")
-colorRed       = lipgloss.Color("#F7768E")
+	colorRed       = lipgloss.Color("#F7768E")
 	colorOrange    = lipgloss.Color("#FF9E64")
 )
 
@@ -214,33 +214,33 @@ func (m Message) GetStyle() lipgloss.Style {
 
 // Model represents the TUI application state
 type Model struct {
-	ready          bool
-	viewportReady  bool
-	width          int
-	height         int
-	quitting       bool
-	completed      bool // whether the loop has finished all iterations
-	messages       []Message
-	maxMessages    int
+	ready           bool
+	viewportReady   bool
+	width           int
+	height          int
+	quitting        bool
+	completed       bool // whether the loop has finished all iterations
+	messages        []Message
+	maxMessages     int
 	spinnerFrame    int // advances each tick to animate in_progress rows
 	inProgressTools int // count of tool rows currently in_progress
-	stats          *stats.TokenStats
-	currentLoop    int
-	totalLoops     int
-	plan           []PlanItem // Agent's TodoWrite-authored plan (ACP plan panel)
-	currentMode    string // Current mode display ("Planning", "Building", or "")
-	modelName      string // Model in use: the --model override, then the effective id from the stream
-	effort         string // Effort level from --effort ("" = claude CLI default)
-	startTime      time.Time
-	baseElapsed    time.Duration // elapsed time from previous sessions
-	timerPaused    bool          // whether elapsed time tracking is paused
-	pausedElapsed  time.Duration // elapsed time when paused (for display)
+	stats           *stats.TokenStats
+	currentLoop     int
+	totalLoops      int
+	plan            []PlanItem // Agent's TodoWrite-authored plan (ACP plan panel)
+	currentMode     string     // Current mode display ("Planning", "Building", or "")
+	modelName       string     // Model in use: the --model override, then the effective id from the stream
+	effort          string     // Effort level from --effort ("" = claude CLI default)
+	startTime       time.Time
+	baseElapsed     time.Duration // elapsed time from previous sessions
+	timerPaused     bool          // whether elapsed time tracking is paused
+	pausedElapsed   time.Duration // elapsed time when paused (for display)
 	// Per-loop tracking for tmux status bar (spec: stats should be about current loop)
-	loopTotalTokens   int64         // tokens accumulated in the current loop iteration
-	loopStartTime     time.Time     // when the current loop iteration started
-	loopBaseElapsed   time.Duration // per-loop elapsed from before pause within same loop
-	loopTimerPaused   bool          // whether per-loop timer is paused
-	loopPausedElapsed time.Duration // per-loop elapsed at time of pause
+	loopTotalTokens   int64          // tokens accumulated in the current loop iteration
+	loopStartTime     time.Time      // when the current loop iteration started
+	loopBaseElapsed   time.Duration  // per-loop elapsed from before pause within same loop
+	loopTimerPaused   bool           // whether per-loop timer is paused
+	loopPausedElapsed time.Duration  // per-loop elapsed at time of pause
 	thinkingViewport  viewport.Model // left half of the 1:1 split: thinking/assistant narrative, word-wrapped
 	toolViewport      viewport.Model // right half of the 1:1 split: tool-use rows + plan panel
 	activityHeight    int
@@ -1434,4 +1434,3 @@ func (m *Model) SetMaxMessagesForTest(n int) {
 func (m *Model) MessageCountForTest() int {
 	return len(m.messages)
 }
-

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -227,11 +227,10 @@ type Model struct {
 	stats          *stats.TokenStats
 	currentLoop    int
 	totalLoops     int
-	currentTask    string // Current task (e.g., "#6 Change the lib/gold into lib/silver")
-	completedTasks int    // Number of completed tasks from plan
-	totalTasks     int    // Total number of tasks from plan
 	plan           []PlanItem // Agent's TodoWrite-authored plan (ACP plan panel)
 	currentMode    string // Current mode display ("Planning", "Building", or "")
+	modelName      string // Model in use: the --model override, then the effective id from the stream
+	effort         string // Effort level from --effort ("" = claude CLI default)
 	startTime      time.Time
 	baseElapsed    time.Duration // elapsed time from previous sessions
 	timerPaused    bool          // whether elapsed time tracking is paused
@@ -323,20 +322,18 @@ func (m *Model) SetPlanFile(path string) {
 	m.planFile = path
 }
 
-// SetCompletedTasks sets the completed/total task counts from the implementation plan
-func (m *Model) SetCompletedTasks(completed, total int) {
-	m.completedTasks = completed
-	m.totalTasks = total
-}
-
 // SetCurrentMode sets the current mode display ("Planning", "Building", or "")
 func (m *Model) SetCurrentMode(mode string) {
 	m.currentMode = mode
 }
 
-// SetCurrentTask sets the initial current task display value
-func (m *Model) SetCurrentTask(task string) {
-	m.currentTask = task
+// SetModelInfo sets the model and effort shown in the Model Details panel.
+// Both come from the CLI flags and may be empty, meaning "whatever the claude
+// CLI defaults to"; the model is refined at runtime by SendModelUpdate once the
+// stream reports the effective model.
+func (m *Model) SetModelInfo(model, effort string) {
+	m.modelName = model
+	m.effort = effort
 }
 
 // getElapsed returns the current total elapsed time
@@ -390,11 +387,6 @@ type statsUpdateMsg struct {
 	stats *stats.TokenStats
 }
 
-// taskUpdateMsg is sent to update the current IMPLEMENTATION_PLAN.md task
-type taskUpdateMsg struct {
-	task string
-}
-
 // toolStatusUpdateMsg is sent to flip an existing tool row's lifecycle status
 // (e.g. in_progress → completed/failed) by matching its tool_use ID.
 type toolStatusUpdateMsg struct {
@@ -407,15 +399,14 @@ type modeUpdateMsg struct {
 	mode string
 }
 
+// modelUpdateMsg is sent to update the effective model reported by the stream
+type modelUpdateMsg struct {
+	model string
+}
+
 // planUpdateMsg replaces the agent's plan (a full-list TodoWrite snapshot).
 type planUpdateMsg struct {
 	items []PlanItem
-}
-
-// completedTasksUpdateMsg is sent to update the completed/total task counts
-type completedTasksUpdateMsg struct {
-	completed int
-	total     int
 }
 
 // loopStartedMsg is sent when a new loop iteration begins (resets per-loop stats)
@@ -566,11 +557,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Reset the loop so the agent re-creates the plan from scratch
 				if m.loop != nil {
 					m.loop.Reset()
-					// Clear completed state and task tracking
+					// Clear completed state and the plan
 					m.completed = false
-					m.completedTasks = 0
-					m.totalTasks = 0
-					m.currentTask = ""
 					m.plan = nil
 					// Resume timers since reset restarts execution
 					if m.timerPaused {
@@ -743,10 +731,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.stats = msg.stats
 		return m, nil
 
-	case taskUpdateMsg:
-		m.currentTask = msg.task
-		return m, nil
-
 	case toolStatusUpdateMsg:
 		// Find the most recent tool row with this ID and update its status
 		// in place. No-op if not found (e.g. row evicted by maxMessages cap).
@@ -773,32 +757,19 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.currentMode = msg.mode
 		return m, nil
 
-	case planUpdateMsg:
-		// Full-list replace. Derive the footer counters from the plan so the
-		// panel and footer share a single source of truth.
-		m.plan = msg.items
-		completed, current := 0, ""
-		for _, it := range msg.items {
-			switch it.Status {
-			case "completed":
-				completed++
-			case "in_progress":
-				if current == "" {
-					current = it.Content
-				}
-			}
+	case modelUpdateMsg:
+		// The stream reports the effective model, which is authoritative over
+		// the --model flag (and is the only source when the flag is empty).
+		if msg.model != "" {
+			m.modelName = msg.model
 		}
-		m.completedTasks = completed
-		m.totalTasks = len(msg.items)
-		if current != "" {
-			m.currentTask = current
-		}
-		m.refreshPanes(false, true)
 		return m, nil
 
-	case completedTasksUpdateMsg:
-		m.completedTasks = msg.completed
-		m.totalTasks = msg.total
+	case planUpdateMsg:
+		// Full-list replace. The plan panel counts progress off m.plan, so this
+		// is the single source of truth for task progress.
+		m.plan = msg.items
+		m.refreshPanes(false, true)
 		return m, nil
 
 	case loopStartedMsg:
@@ -1130,6 +1101,29 @@ func (m Model) renderLayout() string {
 	)
 }
 
+// formatModelName renders a model identifier for the narrow Model Details
+// panel: known tiers collapse to their short name ("claude-opus-4-8" → "opus"),
+// anything else is shown verbatim, and an unknown model reads as "default"
+// (i.e. whatever the claude CLI resolves on its own).
+func formatModelName(model string) string {
+	if model == "" {
+		return "default"
+	}
+	if tier := stats.ModelTier(model); tier != "" {
+		return tier
+	}
+	return model
+}
+
+// formatEffort renders the effort level, or "default" when --effort was not
+// passed and the claude CLI decides.
+func formatEffort(effort string) string {
+	if effort == "" {
+		return "default"
+	}
+	return strings.ToLower(effort)
+}
+
 // renderFooter renders the four-panel footer with hotkey bar
 func (m Model) renderFooter() string {
 	// Four equal panels; each +2 rounded border makes 4*(panelWidth+2) fill
@@ -1229,22 +1223,19 @@ func (m Model) renderFooter() string {
 		row("Status:", statusText, statusStyle),
 	))
 
-	// Task Progress panel
+	// Model Details panel. Task progress lives in the plan panel above, so this
+	// quarter shows what the loop is actually running with.
 	modeDisplay := "-"
 	if m.currentMode != "" {
 		modeDisplay = m.currentMode
 	}
-	taskDisplay := "-"
-	if m.currentTask != "" {
-		taskDisplay = m.currentTask
-	}
 
-	taskProgressPanel := panelStyle.Render(lipgloss.JoinVertical(
+	modelDetailsPanel := panelStyle.Render(lipgloss.JoinVertical(
 		lipgloss.Left,
-		titleStyle.Render("Task Progress"),
-		row("Completed Tasks:", fmt.Sprintf("%d/%d", m.completedTasks, m.totalTasks), valueStyle),
-		row("Current Task:", taskDisplay, valueStyle),
-		row("Current Mode:", modeDisplay, valueStyle),
+		titleStyle.Render("Model Details"),
+		row("Model:", formatModelName(m.modelName), valueStyle),
+		row("Effort:", formatEffort(m.effort), valueStyle),
+		row("Mode:", modeDisplay, valueStyle),
 	))
 
 	// Join panels horizontally
@@ -1253,7 +1244,7 @@ func (m Model) renderFooter() string {
 		tokenUsagePanel,
 		cacheCostPanel,
 		loopDetailsPanel,
-		taskProgressPanel,
+		modelDetailsPanel,
 	)
 
 	// Hotkey bar
@@ -1350,13 +1341,6 @@ func SendStatsUpdate(s *stats.TokenStats) tea.Cmd {
 	}
 }
 
-// SendTaskUpdate is a helper command to update the current task
-func SendTaskUpdate(task string) tea.Cmd {
-	return func() tea.Msg {
-		return taskUpdateMsg{task: task}
-	}
-}
-
 // SendToolStatusUpdate is a helper command to update a tool row's lifecycle
 // status (completed/failed) by its tool_use ID.
 func SendToolStatusUpdate(toolUseID, status string) tea.Cmd {
@@ -1365,8 +1349,8 @@ func SendToolStatusUpdate(toolUseID, status string) tea.Cmd {
 	}
 }
 
-// SendPlanUpdate is a helper command to replace the agent's plan (the panel +
-// footer counters are derived from it).
+// SendPlanUpdate is a helper command to replace the agent's plan (the plan
+// panel is derived from it).
 func SendPlanUpdate(items []PlanItem) tea.Cmd {
 	return func() tea.Msg {
 		return planUpdateMsg{items: items}
@@ -1380,10 +1364,11 @@ func SendModeUpdate(mode string) tea.Cmd {
 	}
 }
 
-// SendCompletedTasksUpdate is a helper command to update completed/total task counts
-func SendCompletedTasksUpdate(completed, total int) tea.Cmd {
+// SendModelUpdate is a helper command to update the effective model shown in
+// the Model Details panel (from the stream's system-init/assistant messages).
+func SendModelUpdate(model string) tea.Cmd {
 	return func() tea.Msg {
-		return completedTasksUpdateMsg{completed: completed, total: total}
+		return modelUpdateMsg{model: model}
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -249,12 +249,10 @@ type Model struct {
 	doneChan          <-chan struct{}
 	loop              *loop.Loop
 	tmuxBar           tmuxBarUpdater
-	hibernating       bool      // whether loop is hibernating due to rate limit
-	hibernateUntil    time.Time // when rate limit resets
-	repoName          string    // git repo name for tmux status bar
-	branchName        string    // git branch name for tmux status bar
-	planFile          string    // path to the implementation plan file (for delete-and-reset)
-	confirmDeletePlan bool      // whether the delete-plan confirmation modal is open
+	repoName          string // git repo name for tmux status bar
+	branchName        string // git branch name for tmux status bar
+	planFile          string // path to the implementation plan file (for delete-and-reset)
+	confirmDeletePlan bool   // whether the delete-plan confirmation modal is open
 }
 
 // NewModel creates and returns a new initialized Model
@@ -352,6 +350,29 @@ func (m Model) getLoopElapsed() time.Duration {
 	return m.loopBaseElapsed + timeNow().Sub(m.loopStartTime)
 }
 
+// isHibernating reports whether the loop is currently rate-limited.
+//
+// The loop is the single source of truth for this state: it both enters
+// hibernation (Loop.Hibernate) and auto-wakes itself when the reset time passes
+// (internal/loop/loop.go). A TUI-local copy of the flag can only be cleared by
+// a manual wake, so it would survive every auto-wake and pin the status display
+// to "RATE LIMITED" for the rest of the session.
+func (m Model) isHibernating() bool {
+	return m.loop != nil && m.loop.IsHibernating()
+}
+
+// hibernateRemaining returns the time left on the current rate-limit window,
+// floored at zero so an elapsed deadline reads as 00:00 rather than counting up.
+func (m Model) hibernateRemaining() time.Duration {
+	if m.loop == nil {
+		return 0
+	}
+	if remaining := m.loop.GetHibernateUntil().Sub(timeNow()); remaining > 0 {
+		return remaining
+	}
+	return 0
+}
+
 // AddMessage adds a message to the activity feed
 func (m *Model) AddMessage(msg Message) {
 	if msg.Role == RoleTool && msg.Status == "in_progress" {
@@ -419,11 +440,6 @@ type loopStatsUpdateMsg struct {
 
 // doneMsg is sent when processing is complete
 type doneMsg struct{}
-
-// hibernateMsg is sent when rate limit is detected
-type hibernateMsg struct {
-	until time.Time
-}
 
 // loopRefMsg is sent to update the loop reference (e.g., when transitioning between plan and build phases)
 type loopRefMsg struct {
@@ -644,7 +660,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				// Handle hibernate wake first
 				if m.loop.IsHibernating() {
 					m.loop.Wake()
-					m.hibernating = false
 					// Resume timers when waking from hibernate
 					if m.timerPaused {
 						m.baseElapsed = m.pausedElapsed
@@ -798,11 +813,6 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
-	case hibernateMsg:
-		m.hibernating = true
-		m.hibernateUntil = msg.until
-		return m, nil
-
 	case loopRefMsg:
 		m.loop = msg.loop
 		return m, nil
@@ -922,7 +932,7 @@ func (m Model) renderThinkingContent() string {
 	// Thinking/waiting indicator: when the loop is live but nothing is
 	// executing, the model is deciding its next step. Animate dots so the
 	// gap between steps reads as active rather than stalled.
-	if m.inProgressTools == 0 && !m.completed && !m.hibernating && !m.quitting && !m.timerPaused {
+	if m.inProgressTools == 0 && !m.completed && !m.isHibernating() && !m.quitting && !m.timerPaused {
 		dots := strings.Repeat(".", 1+(m.spinnerFrame%3))
 		lines = append(lines, dimStyle.Italic(true).Render("💭 thinking"+dots))
 	}
@@ -1044,7 +1054,7 @@ func (m Model) renderDeletePlanModal(layout string) string {
 func (m Model) renderLayout() string {
 	// Check if loop is paused or completed
 	isPaused := m.loop != nil && m.loop.IsPaused()
-	isHibernating := m.loop != nil && m.loop.IsHibernating()
+	isHibernating := m.isHibernating()
 
 	// Choose colors based on state
 	borderColor := colorBlue
@@ -1194,7 +1204,7 @@ func (m Model) renderFooter() string {
 
 	// Status display
 	isPaused := m.loop != nil && m.loop.IsPaused()
-	isHibernating := m.loop != nil && m.loop.IsHibernating()
+	isHibernating := m.isHibernating()
 	statusText := "Running"
 	statusStyle := valueStyle.Foreground(colorGreen)
 	if m.completed {
@@ -1202,10 +1212,7 @@ func (m Model) renderFooter() string {
 		statusStyle = valueStyle.Foreground(colorGreen)
 	} else if isHibernating {
 		// Show countdown timer when hibernating
-		remaining := time.Until(m.hibernateUntil)
-		if remaining < 0 {
-			remaining = 0
-		}
+		remaining := m.hibernateRemaining()
 		mins := int(remaining.Minutes())
 		secs := int(remaining.Seconds()) % 60
 		statusText = fmt.Sprintf("Rate Limited 💤 %02d:%02d", mins, secs)
@@ -1294,11 +1301,8 @@ func (m Model) updateTmuxStatusBar() {
 	}
 
 	// If hibernating, show countdown instead of normal stats
-	if m.hibernating {
-		remaining := m.hibernateUntil.Sub(timeNow())
-		if remaining < 0 {
-			remaining = 0
-		}
+	if m.isHibernating() {
+		remaining := m.hibernateRemaining()
 		mins := int(remaining.Minutes())
 		secs := int(remaining.Seconds()) % 60
 		hibernateDisplay := fmt.Sprintf("RATE LIMITED 💤 %02d:%02d", mins, secs)
@@ -1395,13 +1399,6 @@ func SendLoopStatsUpdate(totalTokens int64) tea.Cmd {
 func SendDone() tea.Cmd {
 	return func() tea.Msg {
 		return doneMsg{}
-	}
-}
-
-// SendHibernate is a helper command to signal rate limit hibernate state
-func SendHibernate(until time.Time) tea.Cmd {
-	return func() tea.Msg {
-		return hibernateMsg{until: until}
 	}
 }
 

--- a/internal/tui/tui.go
+++ b/internal/tui/tui.go
@@ -326,9 +326,11 @@ func (m *Model) SetCurrentMode(mode string) {
 }
 
 // SetModelInfo sets the model and effort shown in the Model Details panel.
-// Both come from the CLI flags and may be empty, meaning "whatever the claude
-// CLI defaults to"; the model is refined at runtime by SendModelUpdate once the
-// stream reports the effective model.
+// The model comes from --model and may be empty, meaning "whatever the claude
+// CLI defaults to"; it is refined at runtime by SendModelUpdate once the stream
+// reports the effective model. Effort has no such stream signal, so callers
+// pass config.ResolveEffort's value — the flag or the settings chain behind it —
+// and empty means no source configured a level at all.
 func (m *Model) SetModelInfo(model, effort string) {
 	m.modelName = model
 	m.effort = effort
@@ -423,6 +425,12 @@ type modeUpdateMsg struct {
 // modelUpdateMsg is sent to update the effective model reported by the stream
 type modelUpdateMsg struct {
 	model string
+}
+
+// effortUpdateMsg is sent to update the effort level read back from the claude
+// session transcript.
+type effortUpdateMsg struct {
+	effort string
 }
 
 // planUpdateMsg replaces the agent's plan (a full-list TodoWrite snapshot).
@@ -780,6 +788,14 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
+	case effortUpdateMsg:
+		// The transcript records the level the CLI resolved for itself, which
+		// outranks both --effort and the settings chain SetModelInfo read.
+		if msg.effort != "" {
+			m.effort = msg.effort
+		}
+		return m, nil
+
 	case planUpdateMsg:
 		// Full-list replace. The plan panel counts progress off m.plan, so this
 		// is the single source of truth for task progress.
@@ -1125,11 +1141,14 @@ func formatModelName(model string) string {
 	return model
 }
 
-// formatEffort renders the effort level, or "default" when --effort was not
-// passed and the claude CLI decides.
+// formatEffort renders the effort level. "default" is not one of them (the
+// levels are low/medium/high/xhigh/max), so an unknown level renders as the
+// same "-" placeholder the Mode row uses. Callers pass the level resolved from
+// --effort or the claude settings chain, so "-" means genuinely unknown rather
+// than merely unflagged.
 func formatEffort(effort string) string {
 	if effort == "" {
-		return "default"
+		return "-"
 	}
 	return strings.ToLower(effort)
 }
@@ -1378,6 +1397,15 @@ func SendModeUpdate(mode string) tea.Cmd {
 func SendModelUpdate(model string) tea.Cmd {
 	return func() tea.Msg {
 		return modelUpdateMsg{model: model}
+	}
+}
+
+// SendEffortUpdate is a helper command to update the effort level shown in the
+// Model Details panel, read back from the claude session transcript. The stream
+// never reports the effort in use, so this is the only runtime source.
+func SendEffortUpdate(effort string) tea.Cmd {
+	return func() tea.Msg {
+		return effortUpdateMsg{effort: effort}
 	}
 }
 

--- a/tests/bdd_autoresearch_test.go
+++ b/tests/bdd_autoresearch_test.go
@@ -543,23 +543,23 @@ func TestBDD_AutoresearchMode_SubtractLoopInResearchingMode(t *testing.T) {
 func TestBDD_AutoresearchMode_FooterFieldOrderingWithResearching(t *testing.T) {
 	// Given: a model with all footer fields populated in Researching mode
 	m, _ := setupReadyModelWithLoop(2, 5)
-	m, _ = sendTuiMsg(m, tui.SendCompletedTasksUpdate(1, 3))
-	m, _ = sendTuiMsg(m, tui.SendTaskUpdate("#1 Run baseline"))
+	m.SetModelInfo("claude-opus-4-8", "high")
+	m, _ = sendTuiMsg(m, tui.SendModelUpdate("claude-opus-4-8"))
 	m, _ = sendTuiMsg(m, tui.SendModeUpdate("Researching"))
 
 	// Then: footer fields appear in expected order with "Researching" last
 	view := m.View()
 	loopIdx := strings.Index(view, "Loop:")
-	modeIdx := strings.Index(view, "Current Mode:")
+	modeIdx := strings.Index(view, "Mode:")
 	researchIdx := strings.Index(view, "Researching")
 
 	if loopIdx == -1 || modeIdx == -1 || researchIdx == -1 {
-		t.Fatalf("Expected Loop, Current Mode, and Researching in view. Loop=%d Mode=%d Researching=%d",
+		t.Fatalf("Expected Loop, Mode, and Researching in view. Loop=%d Mode=%d Researching=%d",
 			loopIdx, modeIdx, researchIdx)
 	}
 
 	if !(loopIdx < modeIdx) {
-		t.Error("Loop should appear before Current Mode in footer")
+		t.Error("Loop should appear before Mode in footer")
 	}
 }
 

--- a/tests/bdd_autoresearch_test.go
+++ b/tests/bdd_autoresearch_test.go
@@ -624,9 +624,7 @@ func TestBDD_AutoresearchMode_HibernateShowsRateLimitedWhileResearching(t *testi
 	m, _ = sendTuiMsg(m, tui.SendModeUpdate("Researching"))
 
 	// When: the loop enters hibernate
-	until := time.Now().Add(5 * time.Minute)
-	l.Hibernate(until)
-	m, _ = sendTuiMsg(m, tui.SendHibernate(until))
+	l.Hibernate(time.Now().Add(5 * time.Minute))
 
 	// Then: status shows RATE LIMITED but mode still shows "Researching"
 	if !viewContains(m, "RATE LIMITED") {

--- a/tests/bdd_exit_app_test.go
+++ b/tests/bdd_exit_app_test.go
@@ -18,7 +18,7 @@ import (
 //
 // These tests verify all exit paths from the TUI: quit via 'q' key, quit via
 // Ctrl+C, elapsed time persistence to stats, and tmux status bar restoration.
-// Organized by user goal following specs/bdd-agent-prompt.md methodology.
+// Organized by user goal: one scenario per user-observable behaviour.
 // ============================================================================
 
 // --- Scenario 1: Quit via 'q' key ---

--- a/tests/bdd_exit_app_test.go
+++ b/tests/bdd_exit_app_test.go
@@ -576,7 +576,7 @@ func TestBDD_UserExitsApplication_QuitWithFullState(t *testing.T) {
 	m.SetTmuxStatusBar(sb)
 	m.AddMessage(tui.Message{Role: tui.RoleAssistant, Content: "Working hard"})
 	m, _ = sendTuiMsg(m, tui.SendModeUpdate("Building"))
-	m, _ = sendTuiMsg(m, tui.SendTaskUpdate("Implementing feature X"))
+	m, _ = sendTuiMsg(m, tui.SendModelUpdate("claude-opus-4-8"))
 	// When: user quits
 	m, cmd := pressKey(m, 'q')
 

--- a/tests/bdd_exit_app_test.go
+++ b/tests/bdd_exit_app_test.go
@@ -466,12 +466,11 @@ func TestBDD_UserExitsApplication_CompletedStatePersistsElapsed(t *testing.T) {
 
 func TestBDD_UserExitsApplication_HibernatingStatePersistsElapsed(t *testing.T) {
 	// Given: a hibernating model with stats
-	m, _ := setupReadyModelWithLoop(2, 5)
+	m, l := setupReadyModelWithLoop(2, 5)
 	tokenStats := stats.NewTokenStats()
 	m.SetStats(tokenStats)
 	m.SetBaseElapsed(20 * time.Minute)
-	until := time.Now().Add(5 * time.Minute)
-	m, _ = sendTuiMsg(m, tui.SendHibernate(until))
+	l.Hibernate(time.Now().Add(5 * time.Minute))
 
 	// When: user quits while hibernating
 	m, _ = pressKey(m, 'q')

--- a/tests/bdd_loop_control_test.go
+++ b/tests/bdd_loop_control_test.go
@@ -432,7 +432,6 @@ func TestBDD_UserControlsLoopExecution_HibernateOverridesStoppedDisplay(t *testi
 	// Given: a loop that is hibernating (which internally may pause)
 	m, l := setupReadyModelWithLoop(2, 5)
 	l.Hibernate(time.Now().Add(3 * time.Minute))
-	m, _ = sendTuiMsg(m, tui.SendHibernate(time.Now().Add(3*time.Minute)))
 
 	// Then: status should show RATE LIMITED (not STOPPED)
 	if viewContains(m, "STOPPED") && viewNotContains(m, "RATE LIMITED") {

--- a/tests/bdd_loop_control_test.go
+++ b/tests/bdd_loop_control_test.go
@@ -621,22 +621,46 @@ func TestBDD_UserControlsLoopExecution_PauseResumeWithRealLoop(t *testing.T) {
 	cancel()
 }
 
-// TestBDD_UserControlsLoopExecution_PerLoopStatsResetOnNewLoop tests that per-loop
-// statistics (tokens, timer) reset when a new loop iteration begins.
+// TestBDD_UserControlsLoopExecution_PerLoopStatsResetOnNewLoop tests that the
+// per-loop token counter on the tmux status bar starts from scratch every time
+// the loop the user is driving rolls over into its next iteration.
+//
+// Given: a running loop whose current iteration has already burned 50k tokens,
+//
+//	reported on the tmux status bar as "tokens: 50k"
+//
+// When: the next loop iteration starts
+// Then: the bar's counter resets to "tokens: 0" and subsequent usage is
+//
+//	attributed to the new iteration alone ("tokens: 100"), so the user always
+//	sees what the iteration in front of them is costing.
 func TestBDD_UserControlsLoopExecution_PerLoopStatsResetOnNewLoop(t *testing.T) {
-	// Given: a model with accumulated per-loop stats
-	m := setupReadyModel()
+	// Given: a running loop with 50k tokens spent in the current iteration
+	m, fakeBar := setupModelWithFakeBar(2, 5)
 	m, _ = sendTuiMsg(m, tui.SendLoopStatsUpdate(50000))
+	m = triggerTick(m)
 
-	// When: a new loop starts
+	if !strings.Contains(fakeBar.LastContent, "tokens: 50k") {
+		t.Fatalf("Precondition: expected 'tokens: 50k' on tmux bar, got: %q", fakeBar.LastContent)
+	}
+
+	// When: a new loop iteration starts
 	m, _ = sendTuiMsg(m, tui.SendLoopStarted())
+	m = triggerTick(m)
 
-	// Then: per-loop stats should be reset
-	// We verify by updating with a small value and checking the model still renders
+	// Then: the per-loop counter is back to zero
+	if !strings.Contains(fakeBar.LastContent, "tokens: 0") {
+		t.Errorf("Expected per-loop tokens to reset to 'tokens: 0', got: %q", fakeBar.LastContent)
+	}
+	if strings.Contains(fakeBar.LastContent, "50k") {
+		t.Errorf("Previous iteration's '50k' should be gone after reset, got: %q", fakeBar.LastContent)
+	}
+
+	// And: usage reported afterwards counts only against the new iteration
 	m, _ = sendTuiMsg(m, tui.SendLoopStatsUpdate(100))
-	view := m.View()
-	if view == "" {
-		t.Error("View should render after per-loop stats reset")
+	triggerTick(m)
+	if !strings.Contains(fakeBar.LastContent, "tokens: 100") {
+		t.Errorf("Expected new iteration's 'tokens: 100' on tmux bar, got: %q", fakeBar.LastContent)
 	}
 }
 

--- a/tests/bdd_loop_control_test.go
+++ b/tests/bdd_loop_control_test.go
@@ -17,7 +17,7 @@ import (
 //
 // These tests verify the complete state machine for loop control:
 // pause, resume, add/subtract loops, start after completion, hibernate wake.
-// Organized by user goal following specs/bdd-agent-prompt.md methodology.
+// Organized by user goal: one scenario per user-observable behaviour.
 // ============================================================================
 
 // --- Helpers ---

--- a/tests/bdd_loop_control_test.go
+++ b/tests/bdd_loop_control_test.go
@@ -94,7 +94,10 @@ func TestBDD_UserControlsLoopExecution_PauseShowsStoppedStatus(t *testing.T) {
 	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 120, Height: 40})
 
 	l.Start(ctx)
-	go func() { for range l.Output() {} }()
+	go func() {
+		for range l.Output() {
+		}
+	}()
 	time.Sleep(50 * time.Millisecond)
 
 	// When: user presses 'p' to pause
@@ -127,7 +130,10 @@ func TestBDD_UserControlsLoopExecution_ResumeShowsRunningStatus(t *testing.T) {
 	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 120, Height: 40})
 
 	l.Start(ctx)
-	go func() { for range l.Output() {} }()
+	go func() {
+		for range l.Output() {
+		}
+	}()
 	time.Sleep(50 * time.Millisecond)
 
 	m, _ = pressKey(m, 'p')
@@ -587,7 +593,10 @@ func TestBDD_UserControlsLoopExecution_PauseResumeWithRealLoop(t *testing.T) {
 	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 120, Height: 40})
 
 	l.Start(ctx)
-	go func() { for range l.Output() {} }()
+	go func() {
+		for range l.Output() {
+		}
+	}()
 
 	time.Sleep(50 * time.Millisecond)
 

--- a/tests/bdd_monitor_progress_test.go
+++ b/tests/bdd_monitor_progress_test.go
@@ -383,14 +383,20 @@ func TestBDD_UserMonitorsBuildProgress_ModelDetailsDefaultWhenUnset(t *testing.T
 	// When: the view is rendered
 	view := m.View()
 
-	// Then: both rows read "default" — i.e. whatever the claude CLI resolves.
+	// Then: the model row reads "default" — whatever the claude CLI resolves,
+	// until the stream reports the effective model. Effort has no such fallback
+	// name: the levels are low/medium/high/xhigh/max, so an unresolved one shows
+	// the "-" placeholder instead of inventing a level that does not exist.
 	// Asserted as complete rows in the Model Details panel rather than by
-	// counting "default" occurrences across the whole view.
+	// counting occurrences across the whole view.
 	rows := modelDetailsRows(t, view)
-	for _, want := range []string{"Model: default", "Effort: default"} {
+	for _, want := range []string{"Model: default", "Effort: -"} {
 		if !panelHasRow(rows, want) {
 			t.Errorf("Expected the row %q in the Model Details panel, got rows: %q", want, rows)
 		}
+	}
+	if panelHasRow(rows, "Effort: default") {
+		t.Errorf("'default' is not an effort level and must not be shown as one, got rows: %q", rows)
 	}
 }
 

--- a/tests/bdd_monitor_progress_test.go
+++ b/tests/bdd_monitor_progress_test.go
@@ -15,8 +15,9 @@ import (
 // BDD Test Suite: User Monitors Build Progress
 //
 // User goal: As a user, I want to monitor the progress of my build by seeing
-// activity messages, loop progress, token usage, agent counts, current task,
-// and mode — so I can understand what Ralph is doing at all times.
+// activity messages, loop progress, token usage, the agent's plan, and the
+// model/effort/mode it is running with — so I can understand what Ralph is
+// doing at all times.
 // =============================================================================
 
 // --- Scenario 1: Empty state shows waiting message ---
@@ -310,58 +311,75 @@ func TestBDD_UserMonitorsBuildProgress_StatsLargeValues(t *testing.T) {
 	}
 }
 
-// --- Scenario 9: Current task updates ---
+// --- Scenario 9: Model details ---
+//
+// Task progress moved to the plan panel above the footer, so the fourth footer
+// panel now answers "what is this loop actually running with?": model + effort.
 
-func TestBDD_UserMonitorsBuildProgress_CurrentTaskUpdates(t *testing.T) {
-	// Given: a ready model
+func TestBDD_UserMonitorsBuildProgress_ModelDetailsShowModelAndEffort(t *testing.T) {
+	// Given: a ready model configured with --model and --effort
 	m := setupReadyModel()
+	m.SetModelInfo("claude-opus-4-8", "high")
 
-	// When: task is updated via message
-	m, _ = sendTuiMsg(m, tui.SendTaskUpdate("#6 Refactor config module"))
-
-	// Then: footer shows the task text (word-wrapped inside the quarter-width
-	// Task Progress panel, so assert the segments rather than one long line)
+	// When: the view is rendered
 	view := m.View()
-	if !strings.Contains(view, "Current Task:") {
-		t.Errorf("Expected 'Current Task:' label in footer")
+
+	// Then: the Model Details panel shows both labels with the model collapsed
+	// to its tier (the quarter-width panel has no room for the full identifier)
+	if !strings.Contains(view, "Model:") {
+		t.Errorf("Expected 'Model:' label in footer, got:\n%s", view)
 	}
-	for _, segment := range []string{"#6 Refactor", "config module"} {
-		if !strings.Contains(view, segment) {
-			t.Errorf("Expected task text segment %q in footer, got:\n%s", segment, view)
-		}
+	if !strings.Contains(view, "Effort:") {
+		t.Errorf("Expected 'Effort:' label in footer, got:\n%s", view)
+	}
+	if !strings.Contains(view, "opus") {
+		t.Errorf("Expected model tier 'opus' in footer, got:\n%s", view)
+	}
+	if !strings.Contains(view, "high") {
+		t.Errorf("Expected effort 'high' in footer, got:\n%s", view)
+	}
+	if strings.Contains(view, "claude-opus-4-8") {
+		t.Errorf("Expected the full model identifier to be collapsed to its tier, got:\n%s", view)
 	}
 }
 
-func TestBDD_UserMonitorsBuildProgress_CurrentTaskDefaultDash(t *testing.T) {
-	// Given: a fresh model with no task set
+func TestBDD_UserMonitorsBuildProgress_ModelUpdateRefinesModel(t *testing.T) {
+	// Given: a model started with --model claude-sonnet-4-5
+	m := setupReadyModel()
+	m.SetModelInfo("claude-sonnet-4-5", "medium")
+	if !viewContains(m, "sonnet") {
+		t.Fatal("Precondition: footer should show the configured 'sonnet' tier")
+	}
+
+	// When: the stream reports a different effective model at runtime
+	m, _ = sendTuiMsg(m, tui.SendModelUpdate("claude-opus-4-8"))
+
+	// Then: the footer shows the effective model and no longer the configured one
+	if !viewContains(m, "opus") {
+		t.Errorf("Expected refined model tier 'opus' in footer, got:\n%s", m.View())
+	}
+	if viewContains(m, "sonnet") {
+		t.Error("Stale model tier 'sonnet' should be replaced by the effective model")
+	}
+	// And: effort is untouched by a model update
+	if !viewContains(m, "medium") {
+		t.Error("Effort should persist across a model update")
+	}
+}
+
+func TestBDD_UserMonitorsBuildProgress_ModelDetailsDefaultWhenUnset(t *testing.T) {
+	// Given: a fresh model with neither --model nor --effort passed
 	m := setupReadyModel()
 
 	// When: the view is rendered
 	view := m.View()
 
-	// Then: shows "Current Task:" label with "-" as default
-	if !strings.Contains(view, "Current Task:") {
-		t.Errorf("Expected 'Current Task:' label in footer")
+	// Then: both rows read "default" — i.e. whatever the claude CLI resolves
+	if !strings.Contains(view, "Model:") || !strings.Contains(view, "Effort:") {
+		t.Fatalf("Expected 'Model:' and 'Effort:' labels in footer, got:\n%s", view)
 	}
-}
-
-func TestBDD_UserMonitorsBuildProgress_CurrentTaskOverwritesPrevious(t *testing.T) {
-	// Given: a model with a task set
-	m := setupReadyModel()
-	m, _ = sendTuiMsg(m, tui.SendTaskUpdate("#1 Old task"))
-	if !viewContains(m, "#1 Old task") {
-		t.Fatal("Precondition: old task should be visible")
-	}
-
-	// When: a new task update arrives
-	m, _ = sendTuiMsg(m, tui.SendTaskUpdate("#2 New task"))
-
-	// Then: only the new task is shown
-	if viewContains(m, "#1 Old task") {
-		t.Error("Old task should not be visible after new task update")
-	}
-	if !viewContains(m, "#2 New task") {
-		t.Error("New task should be visible after update")
+	if n := strings.Count(view, "default"); n < 2 {
+		t.Errorf("Expected model and effort to both render as 'default' (found %d), got:\n%s", n, view)
 	}
 }
 
@@ -386,43 +404,13 @@ func TestBDD_UserMonitorsBuildProgress_ModeTransitions(t *testing.T) {
 
 // --- Additional BDD scenarios for completeness ---
 
-// Scenario: Completed tasks update in footer
-
-func TestBDD_UserMonitorsBuildProgress_CompletedTasksUpdate(t *testing.T) {
-	// Given: a ready model
-	m := setupReadyModel()
-
-	// When: completed tasks are updated
-	m, _ = sendTuiMsg(m, tui.SendCompletedTasksUpdate(4, 7))
-
-	// Then: footer shows "4/7"
-	if !viewContains(m, "4/7") {
-		t.Errorf("Expected completed tasks '4/7' in footer, got:\n%s", m.View())
-	}
-	if !viewContains(m, "Completed Tasks:") {
-		t.Errorf("Expected 'Completed Tasks:' label in footer")
-	}
-}
-
-func TestBDD_UserMonitorsBuildProgress_CompletedTasksDefaultZero(t *testing.T) {
-	// Given: a fresh model with no completed tasks updates
-	m := setupReadyModel()
-
-	// When: the view is rendered
-	// Then: shows "0/0" as default
-	if !viewContains(m, "0/0") {
-		t.Errorf("Expected default completed tasks '0/0' in footer")
-	}
-}
-
 // Scenario: Footer panel ordering
 
 func TestBDD_UserMonitorsBuildProgress_FooterFieldOrdering(t *testing.T) {
 	// Given: a model with all footer fields populated
 	m := setupReadyModel()
+	m.SetModelInfo("claude-opus-4-8", "high")
 	m, _ = sendTuiMsg(m, tui.SendLoopUpdate(2, 5))
-	m, _ = sendTuiMsg(m, tui.SendCompletedTasksUpdate(1, 4))
-	m, _ = sendTuiMsg(m, tui.SendTaskUpdate("#3 Build widget"))
 	m, _ = sendTuiMsg(m, tui.SendModeUpdate("Building"))
 
 	// When: the view is rendered
@@ -431,31 +419,34 @@ func TestBDD_UserMonitorsBuildProgress_FooterFieldOrdering(t *testing.T) {
 	// Then: fields appear in the correct order within their panels. The footer
 	// panels sit side by side, so the view string interleaves them row by row:
 	// vertical order within a panel means a strictly increasing index, and the
-	// Ralph Loop Details panel sits left of the Task Progress panel.
+	// Ralph Loop Details panel sits left of the Model Details panel.
+	//
+	// Note "Model:" and "Mode:" both start with "Mo" but neither is a prefix of
+	// the other ("Model:" is not matched by "Mode:"), so plain Index is safe.
 	loopIdx := strings.Index(view, "Loop:")
 	timeIdx := strings.Index(view, "Total Time:")
 	statusIdx := strings.Index(view, "Status:")
-	completedIdx := strings.Index(view, "Completed Tasks:")
-	taskIdx := strings.Index(view, "Current Task:")
-	modeIdx := strings.Index(view, "Current Mode:")
+	modelIdx := strings.Index(view, "Model:")
+	effortIdx := strings.Index(view, "Effort:")
+	modeIdx := strings.Index(view, "Mode:")
 
 	if loopIdx == -1 || timeIdx == -1 || statusIdx == -1 ||
-		completedIdx == -1 || taskIdx == -1 || modeIdx == -1 {
-		t.Fatalf("Not all footer fields found. Loop=%d Time=%d Status=%d Completed=%d Task=%d Mode=%d",
-			loopIdx, timeIdx, statusIdx, completedIdx, taskIdx, modeIdx)
+		modelIdx == -1 || effortIdx == -1 || modeIdx == -1 {
+		t.Fatalf("Not all footer fields found. Loop=%d Time=%d Status=%d Model=%d Effort=%d Mode=%d",
+			loopIdx, timeIdx, statusIdx, modelIdx, effortIdx, modeIdx)
 	}
 
 	if !(loopIdx < timeIdx && timeIdx < statusIdx) {
 		t.Errorf("Ralph Loop Details fields not in vertical order: Loop@%d < Time@%d < Status@%d",
 			loopIdx, timeIdx, statusIdx)
 	}
-	if !(completedIdx < taskIdx && taskIdx < modeIdx) {
-		t.Errorf("Task Progress fields not in vertical order: Completed@%d < Task@%d < Mode@%d",
-			completedIdx, taskIdx, modeIdx)
+	if !(modelIdx < effortIdx && effortIdx < modeIdx) {
+		t.Errorf("Model Details fields not in vertical order: Model@%d < Effort@%d < Mode@%d",
+			modelIdx, effortIdx, modeIdx)
 	}
-	if !(loopIdx < completedIdx) {
-		t.Errorf("Ralph Loop Details panel should be left of Task Progress panel: Loop@%d < Completed@%d",
-			loopIdx, completedIdx)
+	if !(loopIdx < modelIdx) {
+		t.Errorf("Ralph Loop Details panel should be left of Model Details panel: Loop@%d < Model@%d",
+			loopIdx, modelIdx)
 	}
 }
 
@@ -534,15 +525,17 @@ func TestBDD_UserMonitorsBuildProgress_StatsPersistAcrossAgentChange(t *testing.
 		t.Fatal("Precondition: cost should show $1.500000")
 	}
 
-	// When: task is updated
-	m, _ = sendTuiMsg(m, tui.SendTaskUpdate("#5 Some task"))
+	// When: the agent's plan is updated (task progress lives in the plan panel)
+	m, _ = sendTuiMsg(m, tui.SendPlanUpdate([]tui.PlanItem{
+		{Content: "#5 Some task", Status: "in_progress"},
+	}))
 
 	// Then: stats still show the same cost
 	if !viewContains(m, "$1.500000") {
-		t.Error("Stats should persist when task changes")
+		t.Error("Stats should persist when the plan changes")
 	}
 	if !viewContains(m, "#5 Some task") {
-		t.Error("Task should update to '#5 Some task'")
+		t.Error("Plan panel should show '#5 Some task'")
 	}
 }
 

--- a/tests/bdd_monitor_progress_test.go
+++ b/tests/bdd_monitor_progress_test.go
@@ -634,23 +634,64 @@ func TestBDD_UserMonitorsBuildProgress_LongMessageNotTruncated(t *testing.T) {
 	}
 }
 
-// Scenario: Loop started resets per-loop tracking
+// Scenario: Loop started resets per-loop tracking without disturbing session totals
 
+// TestBDD_UserMonitorsBuildProgress_LoopStartedResetsPerLoopStats
+//
+// The user watches two complementary surfaces: the tmux status bar reports the
+// CURRENT iteration, the TUI footer reports the whole session.
+//
+// Given: a build with 360k cumulative session tokens, 50k of them spent in the
+//
+//	current loop iteration
+//
+// When: a new loop iteration starts
+// Then: the tmux bar's per-loop counter resets to 0 and then tracks only the new
+//
+//	iteration, while the footer keeps reporting the cumulative "Total Tokens:"
+//	(360k) and the RUNNING status — the per-loop reset must not eat the session
+//	totals the user is monitoring.
 func TestBDD_UserMonitorsBuildProgress_LoopStartedResetsPerLoopStats(t *testing.T) {
-	// Given: a model with per-loop stats accumulated
-	m := setupReadyModel()
+	// Given: a running build reporting both cumulative and per-loop usage
+	m, fakeBar := setupModelWithFakeBar(2, 5)
+
+	sessionStats := stats.NewTokenStats()
+	sessionStats.AddUsage(200000, 50000, 10000, 100000) // 360k cumulative
+	m, _ = sendTuiMsg(m, tui.SendStatsUpdate(sessionStats))
 	m, _ = sendTuiMsg(m, tui.SendLoopStatsUpdate(50000))
+	m = triggerTick(m)
+
+	if !strings.Contains(fakeBar.LastContent, "tokens: 50k") {
+		t.Fatalf("Precondition: expected 'tokens: 50k' on tmux bar, got: %q", fakeBar.LastContent)
+	}
+	if !viewContains(m, "360k") {
+		t.Fatalf("Precondition: footer should report cumulative '360k', got:\n%s", m.View())
+	}
 
 	// When: a new loop iteration starts
 	m, _ = sendTuiMsg(m, tui.SendLoopStarted())
+	m = triggerTick(m)
 
-	// Then: the model still renders with the stats panel present
-	// (per-loop tokens are reset internally; the total stats panel remains visible)
+	// Then: the per-loop counter on the tmux bar resets to zero
+	if !strings.Contains(fakeBar.LastContent, "tokens: 0") {
+		t.Errorf("Expected per-loop tokens to reset to 'tokens: 0', got: %q", fakeBar.LastContent)
+	}
+
+	// And: further usage is attributed to the new iteration only
 	m, _ = sendTuiMsg(m, tui.SendLoopStatsUpdate(100))
+	m = triggerTick(m)
+	if !strings.Contains(fakeBar.LastContent, "tokens: 100") {
+		t.Errorf("Expected new iteration's 'tokens: 100' on tmux bar, got: %q", fakeBar.LastContent)
+	}
+
+	// And: the cumulative session figures in the footer are untouched
 	if !viewContains(m, "Total Tokens:") {
-		t.Error("Stats panel should still be present after loop started reset")
+		t.Error("Footer stats panel should still be present after per-loop reset")
+	}
+	if !viewContains(m, "360k") {
+		t.Errorf("Cumulative session total '360k' should survive the per-loop reset, got:\n%s", m.View())
 	}
 	if !viewContains(m, "RUNNING") {
-		t.Error("Status should still show RUNNING after loop started reset")
+		t.Error("Status should still show RUNNING after per-loop reset")
 	}
 }

--- a/tests/bdd_monitor_progress_test.go
+++ b/tests/bdd_monitor_progress_test.go
@@ -325,21 +325,24 @@ func TestBDD_UserMonitorsBuildProgress_ModelDetailsShowModelAndEffort(t *testing
 	view := m.View()
 
 	// Then: the Model Details panel shows both labels with the model collapsed
-	// to its tier (the quarter-width panel has no room for the full identifier)
-	if !strings.Contains(view, "Model:") {
-		t.Errorf("Expected 'Model:' label in footer, got:\n%s", view)
+	// to its tier (the quarter-width panel has no room for the full
+	// identifier). Assertions are scoped to the panel — see modelDetailsPanel —
+	// so short values like "opus"/"high" cannot match text elsewhere.
+	panel := modelDetailsPanel(t, view)
+	rows := modelDetailsRows(t, view)
+
+	if !panelHasRow(rows, "Model: opus") {
+		t.Errorf("Expected the row 'Model: opus' in the Model Details panel, got rows: %q", rows)
 	}
-	if !strings.Contains(view, "Effort:") {
-		t.Errorf("Expected 'Effort:' label in footer, got:\n%s", view)
+	// Exact row, so this cannot be satisfied by "xhigh".
+	if !panelHasRow(rows, "Effort: high") {
+		t.Errorf("Expected the row 'Effort: high' in the Model Details panel, got rows: %q", rows)
 	}
-	if !strings.Contains(view, "opus") {
-		t.Errorf("Expected model tier 'opus' in footer, got:\n%s", view)
+	if strings.Contains(panel, "xhigh") {
+		t.Errorf("Effort 'high' should not render as 'xhigh', got panel:\n%s", panel)
 	}
-	if !strings.Contains(view, "high") {
-		t.Errorf("Expected effort 'high' in footer, got:\n%s", view)
-	}
-	if strings.Contains(view, "claude-opus-4-8") {
-		t.Errorf("Expected the full model identifier to be collapsed to its tier, got:\n%s", view)
+	if strings.Contains(panel, "claude-opus-4-8") {
+		t.Errorf("Expected the full model identifier to be collapsed to its tier, got panel:\n%s", panel)
 	}
 }
 
@@ -347,23 +350,29 @@ func TestBDD_UserMonitorsBuildProgress_ModelUpdateRefinesModel(t *testing.T) {
 	// Given: a model started with --model claude-sonnet-4-5
 	m := setupReadyModel()
 	m.SetModelInfo("claude-sonnet-4-5", "medium")
-	if !viewContains(m, "sonnet") {
+	if !panelHasRow(modelDetailsRows(t, m.View()), "Model: sonnet") {
 		t.Fatal("Precondition: footer should show the configured 'sonnet' tier")
 	}
 
 	// When: the stream reports a different effective model at runtime
 	m, _ = sendTuiMsg(m, tui.SendModelUpdate("claude-opus-4-8"))
 
-	// Then: the footer shows the effective model and no longer the configured one
-	if !viewContains(m, "opus") {
-		t.Errorf("Expected refined model tier 'opus' in footer, got:\n%s", m.View())
+	// Then: the footer shows the effective model and no longer the configured
+	// one. Scoped to the Model Details panel so unrelated view text cannot
+	// satisfy (or break) these short substrings.
+	view := m.View()
+	panel := modelDetailsPanel(t, view)
+	rows := modelDetailsRows(t, view)
+
+	if !panelHasRow(rows, "Model: opus") {
+		t.Errorf("Expected refined row 'Model: opus' in the Model Details panel, got rows: %q", rows)
 	}
-	if viewContains(m, "sonnet") {
-		t.Error("Stale model tier 'sonnet' should be replaced by the effective model")
+	if strings.Contains(panel, "sonnet") {
+		t.Errorf("Stale model tier 'sonnet' should be replaced by the effective model, got panel:\n%s", panel)
 	}
 	// And: effort is untouched by a model update
-	if !viewContains(m, "medium") {
-		t.Error("Effort should persist across a model update")
+	if !panelHasRow(rows, "Effort: medium") {
+		t.Errorf("Effort should persist across a model update, got rows: %q", rows)
 	}
 }
 
@@ -374,12 +383,14 @@ func TestBDD_UserMonitorsBuildProgress_ModelDetailsDefaultWhenUnset(t *testing.T
 	// When: the view is rendered
 	view := m.View()
 
-	// Then: both rows read "default" — i.e. whatever the claude CLI resolves
-	if !strings.Contains(view, "Model:") || !strings.Contains(view, "Effort:") {
-		t.Fatalf("Expected 'Model:' and 'Effort:' labels in footer, got:\n%s", view)
-	}
-	if n := strings.Count(view, "default"); n < 2 {
-		t.Errorf("Expected model and effort to both render as 'default' (found %d), got:\n%s", n, view)
+	// Then: both rows read "default" — i.e. whatever the claude CLI resolves.
+	// Asserted as complete rows in the Model Details panel rather than by
+	// counting "default" occurrences across the whole view.
+	rows := modelDetailsRows(t, view)
+	for _, want := range []string{"Model: default", "Effort: default"} {
+		if !panelHasRow(rows, want) {
+			t.Errorf("Expected the row %q in the Model Details panel, got rows: %q", want, rows)
+		}
 	}
 }
 
@@ -423,30 +434,42 @@ func TestBDD_UserMonitorsBuildProgress_FooterFieldOrdering(t *testing.T) {
 	//
 	// Note "Model:" and "Mode:" both start with "Mo" but neither is a prefix of
 	// the other ("Model:" is not matched by "Mode:"), so plain Index is safe.
+	//
+	// The left-to-right panel ordering is genuinely a whole-view property, so
+	// those indices stay on the full view. The vertical ordering *within* the
+	// Model Details panel is scoped to the extracted panel instead.
 	loopIdx := strings.Index(view, "Loop:")
 	timeIdx := strings.Index(view, "Total Time:")
 	statusIdx := strings.Index(view, "Status:")
 	modelIdx := strings.Index(view, "Model:")
-	effortIdx := strings.Index(view, "Effort:")
-	modeIdx := strings.Index(view, "Mode:")
 
-	if loopIdx == -1 || timeIdx == -1 || statusIdx == -1 ||
-		modelIdx == -1 || effortIdx == -1 || modeIdx == -1 {
-		t.Fatalf("Not all footer fields found. Loop=%d Time=%d Status=%d Model=%d Effort=%d Mode=%d",
-			loopIdx, timeIdx, statusIdx, modelIdx, effortIdx, modeIdx)
+	if loopIdx == -1 || timeIdx == -1 || statusIdx == -1 || modelIdx == -1 {
+		t.Fatalf("Not all footer fields found. Loop=%d Time=%d Status=%d Model=%d",
+			loopIdx, timeIdx, statusIdx, modelIdx)
 	}
 
 	if !(loopIdx < timeIdx && timeIdx < statusIdx) {
 		t.Errorf("Ralph Loop Details fields not in vertical order: Loop@%d < Time@%d < Status@%d",
 			loopIdx, timeIdx, statusIdx)
 	}
-	if !(modelIdx < effortIdx && effortIdx < modeIdx) {
-		t.Errorf("Model Details fields not in vertical order: Model@%d < Effort@%d < Mode@%d",
-			modelIdx, effortIdx, modeIdx)
-	}
 	if !(loopIdx < modelIdx) {
 		t.Errorf("Ralph Loop Details panel should be left of Model Details panel: Loop@%d < Model@%d",
 			loopIdx, modelIdx)
+	}
+
+	// Within the Model Details panel: Model → Effort → Mode, top to bottom.
+	panel := modelDetailsPanel(t, view)
+	panelModelIdx := strings.Index(panel, "Model:")
+	panelEffortIdx := strings.Index(panel, "Effort:")
+	panelModeIdx := strings.Index(panel, "Mode:")
+
+	if panelModelIdx == -1 || panelEffortIdx == -1 || panelModeIdx == -1 {
+		t.Fatalf("Not all Model Details rows found. Model=%d Effort=%d Mode=%d, panel:\n%s",
+			panelModelIdx, panelEffortIdx, panelModeIdx, panel)
+	}
+	if !(panelModelIdx < panelEffortIdx && panelEffortIdx < panelModeIdx) {
+		t.Errorf("Model Details fields not in vertical order: Model@%d < Effort@%d < Mode@%d, panel:\n%s",
+			panelModelIdx, panelEffortIdx, panelModeIdx, panel)
 	}
 }
 

--- a/tests/bdd_rate_limits_test.go
+++ b/tests/bdd_rate_limits_test.go
@@ -1,6 +1,7 @@
 package tests
 
 import (
+	"strings"
 	"testing"
 	"time"
 
@@ -15,7 +16,7 @@ import (
 // rate-limited: banner display, countdown timer, wake action, hotkey bar
 // changes, and activity feed messages. Covers state transitions, boundary
 // conditions, negative paths, and cross-feature interactions.
-// Organized by user goal following specs/bdd-agent-prompt.md methodology.
+// Organized by user goal: one scenario per user-observable behaviour.
 // ============================================================================
 
 // --- Helpers ---
@@ -544,25 +545,29 @@ func TestBDD_UserHandlesRateLimits_LoopProgressVisibleDuringHibernate(t *testing
 
 // --- Helper ---
 
-// extractFooterSection extracts a substring around a keyword for diagnostic output.
+// extractFooterSection returns a window of view around the first occurrence of
+// keyword, for diagnostic output in test failure messages. The window is sliced
+// by rune, because a rendered view is full of multi-byte box-drawing glyphs that
+// byte offsets would split mid-rune. Returns "" when the keyword is absent,
+// rather than silently returning the start of the view.
 func extractFooterSection(view, keyword string) string {
-	idx := 0
-	for i := range view {
-		if i > 0 && view[i-1:i] == keyword[:1] {
-			// Simple prefix match
-			if len(view) >= i+len(keyword)-1 && view[i-1:i+len(keyword)-1] == keyword {
-				idx = i - 1
-				break
-			}
-		}
+	const context = 20
+
+	byteIdx := strings.Index(view, keyword)
+	if byteIdx < 0 {
+		return ""
 	}
-	start := idx - 20
+
+	runes := []rune(view)
+	idx := len([]rune(view[:byteIdx]))
+
+	start := idx - context
 	if start < 0 {
 		start = 0
 	}
-	end := idx + len(keyword) + 20
-	if end > len(view) {
-		end = len(view)
+	end := idx + len([]rune(keyword)) + context
+	if end > len(runes) {
+		end = len(runes)
 	}
-	return view[start:end]
+	return string(runes[start:end])
 }

--- a/tests/bdd_rate_limits_test.go
+++ b/tests/bdd_rate_limits_test.go
@@ -22,12 +22,12 @@ import (
 // --- Helpers ---
 
 // setupHibernatingModel creates a ready model with a loop in hibernate state.
-// Both loop-level and TUI-level hibernate state are set, matching the real pipeline.
+// The loop is the single source of truth for rate-limit state — the TUI reads it
+// back off the loop on every render — so hibernating the loop is all that is
+// needed to put the whole UI into the rate-limited state.
 func setupHibernatingModel(current, total int, hibernateDuration time.Duration) (tui.Model, *loop.Loop) {
 	m, l := setupReadyModelWithLoop(current, total)
-	until := time.Now().Add(hibernateDuration)
-	l.Hibernate(until)
-	m, _ = sendTuiMsg(m, tui.SendHibernate(until))
+	l.Hibernate(time.Now().Add(hibernateDuration))
 	return m, l
 }
 
@@ -45,20 +45,15 @@ func TestBDD_UserHandlesRateLimits_HibernateShowsRateLimitedBanner(t *testing.T)
 
 func TestBDD_UserHandlesRateLimits_HibernateBannerReplacesRunning(t *testing.T) {
 	// Given: a model that was previously showing RUNNING
-	m, _ := setupReadyModelWithLoop(2, 5)
+	m, l := setupReadyModelWithLoop(2, 5)
 
 	// Precondition: shows RUNNING before hibernate
 	if !viewContains(m, "RUNNING") {
 		t.Fatal("Precondition: should show RUNNING before hibernate")
 	}
 
-	// When: hibernate is triggered
-	until := time.Now().Add(5 * time.Minute)
-	m, _ = sendTuiMsg(m, tui.SendHibernate(until))
-	// Note: we also need the loop to be hibernating for renderLayout to detect it
-	// The view checks m.loop.IsHibernating(), so we need the loop reference
-	// Re-setup with full hibernate state
-	m, _ = setupHibernatingModel(2, 5, 5*time.Minute)
+	// When: hibernate is triggered on the loop the model already holds
+	l.Hibernate(time.Now().Add(5 * time.Minute))
 
 	// Then: RATE LIMITED replaces RUNNING
 	if !viewContains(m, "RATE LIMITED") {
@@ -75,9 +70,7 @@ func TestBDD_UserHandlesRateLimits_HibernateOverridesStoppedDisplay(t *testing.T
 	m, l := setupReadyModelWithLoop(2, 5)
 
 	// Hibernate the loop (this internally sets hibernating=true)
-	until := time.Now().Add(5 * time.Minute)
-	l.Hibernate(until)
-	m, _ = sendTuiMsg(m, tui.SendHibernate(until))
+	l.Hibernate(time.Now().Add(5 * time.Minute))
 
 	// Precondition: view shows RATE LIMITED
 	if !viewContains(m, "RATE LIMITED") {
@@ -141,9 +134,7 @@ func TestBDD_UserHandlesRateLimits_CountdownShowsRateLimitedPrefix(t *testing.T)
 func TestBDD_UserHandlesRateLimits_CountdownAtZeroBoundary(t *testing.T) {
 	// Given: a hibernating loop where the deadline has already passed
 	m, l := setupReadyModelWithLoop(2, 5)
-	past := time.Now().Add(-1 * time.Second)
-	l.Hibernate(past)
-	m, _ = sendTuiMsg(m, tui.SendHibernate(past))
+	l.Hibernate(time.Now().Add(-1 * time.Second))
 
 	// Precondition: view shows RATE LIMITED (loop stays hibernating even if deadline passed)
 	if !viewContains(m, "RATE LIMITED") {
@@ -260,6 +251,54 @@ func TestBDD_UserHandlesRateLimits_SKeyAlsoWakesFromHibernate(t *testing.T) {
 	// Then: RATE LIMITED should be cleared
 	if viewContains(m, "RATE LIMITED") {
 		t.Error("RATE LIMITED should be cleared after 's' key wake")
+	}
+}
+
+// TestBDD_UserHandlesRateLimits_AutoWakeClearsRateLimitedDisplayWithoutKeypress
+//
+// The loop wakes itself once the rate-limit deadline passes — the hibernate
+// branch of the run goroutine in internal/loop/loop.go clears the hibernating
+// flag with no user involvement at all. Calling l.Wake() directly here stands in
+// for that automatic wake.
+//
+// The absence of a keypress is the whole point of this test. While the TUI kept
+// its own copy of the hibernate flag, that copy was only ever cleared by the
+// 'r'/'s' key handler, so every automatic wake left the display stuck: the tmux
+// bar pinned at "RATE LIMITED 💤 00:00" and the 💭 thinking indicator suppressed
+// for the rest of the session. Do NOT send a key anywhere below — the display
+// must recover from the loop's own state change alone.
+func TestBDD_UserHandlesRateLimits_AutoWakeClearsRateLimitedDisplayWithoutKeypress(t *testing.T) {
+	// Given: a hibernating loop whose TUI and tmux bar both show the rate limit
+	m, l := setupHibernatingModel(2, 5, 5*time.Minute)
+	fakeBar := &tui.FakeStatusBarForTest{}
+	m.SetTmuxStatusBar(fakeBar)
+
+	if !viewContains(m, "RATE LIMITED") {
+		t.Fatal("Precondition: view should show RATE LIMITED while hibernating")
+	}
+	m = triggerTick(m)
+	if !strings.Contains(fakeBar.LastContent, "RATE LIMITED") {
+		t.Fatalf("Precondition: tmux bar should show RATE LIMITED while hibernating, got: %q", fakeBar.LastContent)
+	}
+
+	// When: the loop wakes itself because the deadline elapsed — no keypress
+	l.Wake()
+
+	// Then: the banner stops claiming a rate limit
+	if viewContains(m, "RATE LIMITED") {
+		t.Error("View still shows RATE LIMITED after the loop auto-woke — the TUI is holding a stale copy of the hibernate state")
+	}
+
+	// And: the next tick puts normal per-loop stats back on the tmux bar
+	triggerTick(m)
+	if strings.Contains(fakeBar.LastContent, "RATE LIMITED") {
+		t.Errorf("tmux bar still shows RATE LIMITED after the loop auto-woke, got: %q", fakeBar.LastContent)
+	}
+	if !strings.Contains(fakeBar.LastContent, "loop:") {
+		t.Errorf("Expected the 'loop:' stats field back on the tmux bar after auto-wake, got: %q", fakeBar.LastContent)
+	}
+	if !strings.Contains(fakeBar.LastContent, "elapsed:") {
+		t.Errorf("Expected the 'elapsed:' stats field back on the tmux bar after auto-wake, got: %q", fakeBar.LastContent)
 	}
 }
 
@@ -396,9 +435,7 @@ func TestBDD_UserHandlesRateLimits_HibernateDuringCompletedState(t *testing.T) {
 	}
 
 	// When: hibernate is triggered (edge case: rate limit after completion)
-	until := time.Now().Add(3 * time.Minute)
-	l.Hibernate(until)
-	m, _ = sendTuiMsg(m, tui.SendHibernate(until))
+	l.Hibernate(time.Now().Add(3 * time.Minute))
 
 	// Then: COMPLETED takes precedence over RATE LIMITED
 	// (completed is checked first in renderLayout)
@@ -468,21 +505,23 @@ func TestBDD_UserHandlesRateLimits_WakeWhenNotHibernating(t *testing.T) {
 }
 
 func TestBDD_UserHandlesRateLimits_HibernateWithoutLoop(t *testing.T) {
-	// Given: a model with no loop set
+	// Given: a model with no loop set (edge case: the TUI is rendered before the
+	// loop reference has been wired in)
 	m := setupReadyModel()
 
-	// When: hibernate message is sent (edge case: message arrives before loop is set)
-	until := time.Now().Add(5 * time.Minute)
-	m, _ = sendTuiMsg(m, tui.SendHibernate(until))
-
-	// Then: no crash — model renders without RATE LIMITED in the banner
-	// (renderLayout checks m.loop != nil && m.loop.IsHibernating())
+	// Then: the model renders without crashing...
 	view := m.View()
 	if view == "" {
-		t.Error("Expected non-empty view after hibernate message without loop")
+		t.Error("Expected non-empty view for a model with no loop")
 	}
-	// The RATE LIMITED banner requires both TUI state AND loop state
-	// Without a loop, the banner check returns false
+	// ...and is by definition NOT rate-limited: the loop owns that state, so a
+	// model with no loop has nothing that could put it into hibernation.
+	if strings.Contains(view, "RATE LIMITED") {
+		t.Error("A model with no loop must never show 'RATE LIMITED'")
+	}
+	if strings.Contains(view, "Rate Limited") {
+		t.Error("A model with no loop must never show the 'Rate Limited' countdown")
+	}
 }
 
 // --- State transition: Multiple hibernate/wake cycles ---
@@ -493,9 +532,7 @@ func TestBDD_UserHandlesRateLimits_MultipleHibernateWakeCycles(t *testing.T) {
 
 	for i := 0; i < 3; i++ {
 		// When: hibernate is triggered
-		until := time.Now().Add(5 * time.Minute)
-		l.Hibernate(until)
-		m, _ = sendTuiMsg(m, tui.SendHibernate(until))
+		l.Hibernate(time.Now().Add(5 * time.Minute))
 
 		// Then: shows RATE LIMITED
 		if !viewContains(m, "RATE LIMITED") {
@@ -517,9 +554,7 @@ func TestBDD_UserHandlesRateLimits_HibernateExtendsDeadline(t *testing.T) {
 	m, l := setupHibernatingModel(2, 5, 2*time.Minute)
 
 	// When: a second hibernate extends the deadline to 10 minutes
-	longerUntil := time.Now().Add(10 * time.Minute)
-	l.Hibernate(longerUntil)
-	m, _ = sendTuiMsg(m, tui.SendHibernate(longerUntil))
+	l.Hibernate(time.Now().Add(10 * time.Minute))
 
 	// Then: countdown shows the extended time (~10 minutes)
 	if !viewContains(m, "09:") && !viewContains(m, "10:") {

--- a/tests/bdd_terminal_adapt_test.go
+++ b/tests/bdd_terminal_adapt_test.go
@@ -532,4 +532,3 @@ func TestBDD_UserAdaptsToTerminal_TickDuringPreInit(t *testing.T) {
 		t.Error("View should remain empty during pre-init even after tick")
 	}
 }
-

--- a/tests/bdd_terminal_adapt_test.go
+++ b/tests/bdd_terminal_adapt_test.go
@@ -17,7 +17,7 @@ import (
 // normal, message preservation across resizes, boundary conditions, and
 // pre-init state. Covers state transitions, boundary conditions, negative
 // paths, and cross-feature interactions.
-// Organized by user goal following specs/bdd-agent-prompt.md methodology.
+// Organized by user goal: one scenario per user-observable behaviour.
 // ============================================================================
 
 // --- Scenario 1: Too-small terminal shows warning message ---

--- a/tests/bdd_thinking_test.go
+++ b/tests/bdd_thinking_test.go
@@ -96,7 +96,9 @@ func TestBDD_ThinkingDisplay_ThinkingAndAssistantMessagesCoexist(t *testing.T) {
 // TestBDD_ThinkingDisplay_ThinkingViaChannelDelivery
 //
 // Given: a model created with NewModelWithChannels and a thinking message
-//        pre-loaded into the channel
+//
+//	pre-loaded into the channel
+//
 // When: the channel listener delivers the message
 // Then: the thinking icon and content appear in the activity feed
 func TestBDD_ThinkingDisplay_ThinkingViaChannelDelivery(t *testing.T) {

--- a/tests/bdd_tmux_test.go
+++ b/tests/bdd_tmux_test.go
@@ -4,16 +4,26 @@ package tests
 // BDD Test Suite: Tmux Status Bar Content (Task 8)
 //
 // User goal: while ralph is running inside tmux, the status bar shows repo name,
-// branch, loop progress, and session uptime so the user can monitor build
-// progress at a glance without looking at the TUI.
+// branch and the stats of the CURRENT LOOP ITERATION — progress, tokens burned
+// and time spent in this iteration — so the user can judge how the running
+// iteration is going at a glance without looking at the TUI.
+//
+// Cumulative session figures deliberately do NOT live here: they stay in the TUI
+// footer ("Total Tokens" / "Total Time"), so the two surfaces complement each
+// other instead of duplicating.
 //
 // updateTmuxStatusBar() is called on every tick and formats the content as:
 //
-//	[repo | branch | loop: N/M, uptime: HH:MM:SS]
+//	[repo | branch | loop: N/M, tokens: 45k, elapsed: HH:MM:SS]
 //
-// During hibernation it shows:
+// Both `tokens:` and `elapsed:` reset when a new iteration begins
+// (tui.SendLoopStarted), which is what makes them per-loop rather than session
+// totals.
 //
-//	[repo | branch | RATE LIMITED 💤 MM:SS]
+// During hibernation the loop field carries the countdown and the token/elapsed
+// fields are omitted entirely — no dangling labels:
+//
+//	[repo | branch | loop: RATE LIMITED 💤 MM:SS]
 //
 // These tests inject a FakeStatusBarForTest, trigger a tick, and assert the
 // content passed to the fake bar matches expectations.
@@ -113,40 +123,105 @@ func TestBDD_TmuxStatusBar_RepoBranchShownOnTick(t *testing.T) {
 	}
 }
 
-// --- Scenario 4: Session uptime shown ---
+// --- Scenario 4: Elapsed time is per-loop, not per-session ---
 
-// TestBDD_TmuxStatusBar_ElapsedTimeShownOnTick
+// TestBDD_TmuxStatusBar_ElapsedTimeIsPerLoopNotSession
 //
-// Given: a model where 65 seconds of session uptime have elapsed (mocked time)
-// When: a tick occurs
-// Then: the tmux bar content includes "00:01:05"
-func TestBDD_TmuxStatusBar_ElapsedTimeShownOnTick(t *testing.T) {
+// Given: a model that has been running for 65s inside its first loop iteration
+// When: a new loop iteration starts and time keeps advancing (mocked clock)
+// Then: the bar's "elapsed:" field restarts from 00:00:00 and counts from the
+// loop start, while the cumulative session time keeps running in the TUI footer
+func TestBDD_TmuxStatusBar_ElapsedTimeIsPerLoopNotSession(t *testing.T) {
 	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
-	tui.SetTimeNowForTest(func() time.Time { return baseTime })
+	now := baseTime
+	tui.SetTimeNowForTest(func() time.Time { return now })
 	defer tui.SetTimeNowForTest(time.Now)
 
-	// Given: model created at baseTime (loopStartTime = baseTime)
+	// Given: a model created at baseTime (session start == first loop start)
 	m, fakeBar := setupModelWithFakeBar(1, 3)
 
-	// Advance time by 65 seconds
-	tui.SetTimeNowForTest(func() time.Time { return baseTime.Add(65 * time.Second) })
+	// And: 65 seconds pass inside the first iteration
+	now = baseTime.Add(65 * time.Second)
+	m = triggerTick(m)
 
-	// When: tick
-	triggerTick(m)
+	if !strings.Contains(fakeBar.LastContent, "elapsed: 00:01:05") {
+		t.Fatalf("Precondition: expected 'elapsed: 00:01:05' after 65s in the first loop, got: %q", fakeBar.LastContent)
+	}
 
-	// Then: elapsed time shown as HH:MM:SS
-	if !strings.Contains(fakeBar.LastContent, "00:01:05") {
-		t.Errorf("Expected 00:01:05 in tmux bar, got: %q", fakeBar.LastContent)
+	// When: a new loop iteration starts, with no wall-clock time passing
+	m, _ = sendTuiMsg(m, tui.SendLoopStarted())
+	m = triggerTick(m)
+
+	// Then: the bar's elapsed field resets to zero for the new iteration...
+	if !strings.Contains(fakeBar.LastContent, "elapsed: 00:00:00") {
+		t.Errorf("Expected 'elapsed: 00:00:00' immediately after a new loop started, got: %q", fakeBar.LastContent)
+	}
+	if strings.Contains(fakeBar.LastContent, "00:01:05") {
+		t.Errorf("Bar still shows 00:01:05 after the loop restarted — it is reporting session time, not loop time: %q", fakeBar.LastContent)
+	}
+
+	// ...even though the session clock never stopped: the footer still shows 65s.
+	if !viewContains(m, "00:01:05") {
+		t.Errorf("Expected the TUI footer to still show cumulative session time 00:01:05, view:\n%s", m.View())
+	}
+
+	// When: 30 more seconds pass inside the second iteration (session total 1m35s)
+	now = now.Add(30 * time.Second)
+	m = triggerTick(m)
+
+	// Then: the bar counts from the loop start (30s), not the session start (1m35s)
+	if !strings.Contains(fakeBar.LastContent, "elapsed: 00:00:30") {
+		t.Errorf("Expected 'elapsed: 00:00:30' (time since the loop started), got: %q", fakeBar.LastContent)
+	}
+	if strings.Contains(fakeBar.LastContent, "00:01:35") {
+		t.Errorf("Bar shows session elapsed 00:01:35 instead of loop elapsed 00:00:30: %q", fakeBar.LastContent)
+	}
+	if !viewContains(m, "00:01:35") {
+		t.Errorf("Expected the TUI footer to show cumulative session time 00:01:35, view:\n%s", m.View())
 	}
 }
 
-// --- Scenario 5: Hibernating state shows RATE LIMITED label ---
+// --- Scenario 5: Token count is per-loop and resets on a new loop ---
+
+// TestBDD_TmuxStatusBar_LoopTokensShownAndResetOnNewLoop
+//
+// Given: a model whose current iteration has consumed 45,000 tokens
+// When: a tick occurs, and later a new loop iteration starts
+// Then: the bar shows "tokens: 45k", then resets to "tokens: 0"
+func TestBDD_TmuxStatusBar_LoopTokensShownAndResetOnNewLoop(t *testing.T) {
+	m, fakeBar := setupModelWithFakeBar(2, 5)
+
+	// Given: the current iteration reports 45,000 tokens
+	m, _ = sendTuiMsg(m, tui.SendLoopStatsUpdate(45000))
+
+	// When: tick
+	m = triggerTick(m)
+
+	// Then: the per-loop token count reaches the bar in humanised form
+	if !strings.Contains(fakeBar.LastContent, "tokens: 45k") {
+		t.Errorf("Expected 'tokens: 45k' in tmux bar, got: %q", fakeBar.LastContent)
+	}
+
+	// When: a new loop iteration starts and another tick occurs
+	m, _ = sendTuiMsg(m, tui.SendLoopStarted())
+	m = triggerTick(m)
+
+	// Then: the token count resets for the new iteration
+	if !strings.Contains(fakeBar.LastContent, "tokens: 0") {
+		t.Errorf("Expected 'tokens: 0' after a new loop started, got: %q", fakeBar.LastContent)
+	}
+	if strings.Contains(fakeBar.LastContent, "45k") {
+		t.Errorf("Bar still shows the previous iteration's 45k tokens — tokens are cumulative, not per-loop: %q", fakeBar.LastContent)
+	}
+}
+
+// --- Scenario 6: Hibernating state shows RATE LIMITED label ---
 
 // TestBDD_TmuxStatusBar_RateLimitedLabelShownDuringHibernate
 //
 // Given: a model in hibernating state (both loop and TUI state set)
 // When: a tick occurs
-// Then: the tmux bar content includes "RATE LIMITED"
+// Then: the tmux bar shows "RATE LIMITED" and omits the token/elapsed fields
 func TestBDD_TmuxStatusBar_RateLimitedLabelShownDuringHibernate(t *testing.T) {
 	// Given: model and loop both in hibernate state (matches real pipeline)
 	m, _ := setupHibernatingModel(2, 5, 5*time.Minute)
@@ -165,15 +240,24 @@ func TestBDD_TmuxStatusBar_RateLimitedLabelShownDuringHibernate(t *testing.T) {
 	if !strings.Contains(fakeBar.LastContent, "RATE LIMITED") {
 		t.Errorf("Expected RATE LIMITED in tmux bar during hibernate, got: %q", fakeBar.LastContent)
 	}
+
+	// And: no dangling per-loop labels while nothing is running
+	if strings.Contains(fakeBar.LastContent, "tokens:") {
+		t.Errorf("Expected no 'tokens:' field during hibernate, got: %q", fakeBar.LastContent)
+	}
+	if strings.Contains(fakeBar.LastContent, "elapsed:") {
+		t.Errorf("Expected no 'elapsed:' field during hibernate, got: %q", fakeBar.LastContent)
+	}
 }
 
-// --- Scenario 6: Hibernating state shows sleep emoji countdown ---
+// --- Scenario 7: Hibernating state shows sleep emoji countdown ---
 
 // TestBDD_TmuxStatusBar_SleepEmojiCountdownShownDuringHibernate
 //
 // Given: a model in hibernating state with 3 minutes 30 seconds remaining (mocked time)
 // When: a tick occurs
-// Then: the tmux bar content includes "💤 03:30"
+// Then: the tmux bar content is exactly the hibernate variant "[repo | branch |
+// loop: RATE LIMITED 💤 03:30]" — countdown present, token/elapsed fields absent
 func TestBDD_TmuxStatusBar_SleepEmojiCountdownShownDuringHibernate(t *testing.T) {
 	baseTime := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
 	tui.SetTimeNowForTest(func() time.Time { return baseTime })
@@ -183,6 +267,7 @@ func TestBDD_TmuxStatusBar_SleepEmojiCountdownShownDuringHibernate(t *testing.T)
 	// hibernateUntil is baseTime + 3m30s; timeNow() is baseTime → 3m30s remain
 	hibernateUntil := baseTime.Add(3*time.Minute + 30*time.Second)
 	m, _ := setupReadyModelWithLoop(2, 5)
+	m.SetGitContext("ralph", "main")
 	m, _ = sendTuiMsg(m, tui.SendHibernate(hibernateUntil))
 
 	fakeBar := &tui.FakeStatusBarForTest{}
@@ -195,9 +280,23 @@ func TestBDD_TmuxStatusBar_SleepEmojiCountdownShownDuringHibernate(t *testing.T)
 	if !strings.Contains(fakeBar.LastContent, "💤 03:30") {
 		t.Errorf("Expected '💤 03:30' in tmux bar during hibernate, got: %q", fakeBar.LastContent)
 	}
+
+	// And: the hibernate variant carries no per-loop token/elapsed fields
+	if strings.Contains(fakeBar.LastContent, "tokens:") {
+		t.Errorf("Expected no 'tokens:' field during hibernate, got: %q", fakeBar.LastContent)
+	}
+	if strings.Contains(fakeBar.LastContent, "elapsed:") {
+		t.Errorf("Expected no 'elapsed:' field during hibernate, got: %q", fakeBar.LastContent)
+	}
+
+	// And: the whole bar is the documented hibernate format
+	wantHibernate := "[ralph | main | loop: RATE LIMITED 💤 03:30]"
+	if fakeBar.LastContent != wantHibernate {
+		t.Errorf("Expected hibernate bar %q, got: %q", wantHibernate, fakeBar.LastContent)
+	}
 }
 
-// --- Scenario 7: No update when tmux bar is inactive ---
+// --- Scenario 8: No update when tmux bar is inactive ---
 
 // TestBDD_TmuxStatusBar_NoUpdateWhenBarNotSet
 //
@@ -214,27 +313,42 @@ func TestBDD_TmuxStatusBar_NoUpdateWhenBarNotSet(t *testing.T) {
 	// Then: no panic (test passes if we get here)
 }
 
-// --- Scenario 8: Full status bar format ---
+// --- Scenario 9: Full status bar format ---
 
 // TestBDD_TmuxStatusBar_FullFormatContainsAllFields
 //
-// Given: a model with loop at 3/7, git context set, 0 elapsed
+// Given: a model with loop at 3/7, git context set, frozen clock and no tokens yet
 // When: a tick occurs
-// Then: the tmux bar uses the expected format with all fields present
+// Then: the bar is exactly "[ralph | main | loop: 3/7, tokens: 0, elapsed: 00:00:00]"
+// with the current labels ("elapsed:", not the old "uptime:")
 func TestBDD_TmuxStatusBar_FullFormatContainsAllFields(t *testing.T) {
+	frozen := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	tui.SetTimeNowForTest(func() time.Time { return frozen })
+	defer tui.SetTimeNowForTest(time.Now)
+
 	m, fakeBar := setupModelWithFakeBar(3, 7)
 	m.SetGitContext("ralph", "main")
 
 	// When: tick
-	triggerTick(m)
+	m = triggerTick(m)
 
 	// Then: all fields present in correct format
 	content := fakeBar.LastContent
+	want := "[ralph | main | loop: 3/7, tokens: 0, elapsed: 00:00:00]"
+	if content != want {
+		t.Errorf("Expected tmux bar %q, got: %q", want, content)
+	}
 	if !strings.Contains(content, "loop:") {
 		t.Errorf("Expected 'loop:' label in tmux bar, got: %q", content)
 	}
-	if !strings.Contains(content, "uptime:") {
-		t.Errorf("Expected 'uptime:' label in tmux bar, got: %q", content)
+	if !strings.Contains(content, "tokens:") {
+		t.Errorf("Expected 'tokens:' label in tmux bar, got: %q", content)
+	}
+	if !strings.Contains(content, "elapsed:") {
+		t.Errorf("Expected 'elapsed:' label in tmux bar, got: %q", content)
+	}
+	if strings.Contains(content, "uptime:") {
+		t.Errorf("Expected the old 'uptime:' label to be gone, got: %q", content)
 	}
 	if !strings.Contains(content, "3/7") {
 		t.Errorf("Expected '3/7' in tmux bar, got: %q", content)

--- a/tests/bdd_tmux_test.go
+++ b/tests/bdd_tmux_test.go
@@ -219,11 +219,11 @@ func TestBDD_TmuxStatusBar_LoopTokensShownAndResetOnNewLoop(t *testing.T) {
 
 // TestBDD_TmuxStatusBar_RateLimitedLabelShownDuringHibernate
 //
-// Given: a model in hibernating state (both loop and TUI state set)
+// Given: a model whose loop is hibernating
 // When: a tick occurs
 // Then: the tmux bar shows "RATE LIMITED" and omits the token/elapsed fields
 func TestBDD_TmuxStatusBar_RateLimitedLabelShownDuringHibernate(t *testing.T) {
-	// Given: model and loop both in hibernate state (matches real pipeline)
+	// Given: the loop in hibernate state (matches real pipeline)
 	m, _ := setupHibernatingModel(2, 5, 5*time.Minute)
 	fakeBar := &tui.FakeStatusBarForTest{}
 	m.SetTmuxStatusBar(fakeBar)
@@ -263,12 +263,12 @@ func TestBDD_TmuxStatusBar_SleepEmojiCountdownShownDuringHibernate(t *testing.T)
 	tui.SetTimeNowForTest(func() time.Time { return baseTime })
 	defer tui.SetTimeNowForTest(time.Now)
 
-	// Given: model and loop both in hibernate state with 3m30s remaining
+	// Given: the loop hibernating with 3m30s remaining
 	// hibernateUntil is baseTime + 3m30s; timeNow() is baseTime → 3m30s remain
 	hibernateUntil := baseTime.Add(3*time.Minute + 30*time.Second)
-	m, _ := setupReadyModelWithLoop(2, 5)
+	m, l := setupReadyModelWithLoop(2, 5)
 	m.SetGitContext("ralph", "main")
-	m, _ = sendTuiMsg(m, tui.SendHibernate(hibernateUntil))
+	l.Hibernate(hibernateUntil)
 
 	fakeBar := &tui.FakeStatusBarForTest{}
 	m.SetTmuxStatusBar(fakeBar)

--- a/tests/effort_test.go
+++ b/tests/effort_test.go
@@ -1,0 +1,224 @@
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cloudosai/ralph-go/internal/config"
+)
+
+// ============================================================================
+// Tests: effort resolution
+//
+// The claude CLI's effort levels are low/medium/high/xhigh/max. Ralph knows
+// which one is in force from two sources, because the stream-json output it
+// parses never names one:
+//
+//	ResolveEffort     — --effort, else `effortLevel` in the settings chain.
+//	                    Available immediately, at startup.
+//	TranscriptEffort  — the level the CLI recorded on the session's assistant
+//	                    records. Ground truth, but only once the session is
+//	                    under way.
+//
+// Both are display-only; neither changes what is passed to `claude --effort`.
+// ============================================================================
+
+// writeSettings writes a .claude/settings file with the given raw JSON body,
+// creating the parent directories.
+func writeSettings(t *testing.T, path, body string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+// isolateSettings points both ends of the settings chain at temp directories:
+// the working directory (for .claude/settings*.json) and HOME (for the global
+// one). Without this, the developer's own ~/.claude/settings.json leaks in and
+// the "nothing configured" cases pass or fail by accident.
+func isolateSettings(t *testing.T) {
+	t.Helper()
+
+	t.Chdir(t.TempDir())
+	t.Setenv("HOME", t.TempDir())
+}
+
+func TestResolveEffort_FlagWins(t *testing.T) {
+	isolateSettings(t)
+	writeSettings(t, filepath.Join(".claude", "settings.json"), `{"effortLevel":"low"}`)
+
+	// --effort goes on the command line, so it beats any settings file — the
+	// settings value must not be reported as the level in force.
+	if got := config.ResolveEffort("max"); got != "max" {
+		t.Errorf("ResolveEffort(\"max\") = %q, want \"max\" (the flag outranks settings)", got)
+	}
+}
+
+func TestResolveEffort_ReadsProjectSettings(t *testing.T) {
+	isolateSettings(t)
+	writeSettings(t, filepath.Join(".claude", "settings.json"), `{"effortLevel":"high"}`)
+
+	if got := config.ResolveEffort(""); got != "high" {
+		t.Errorf("ResolveEffort(\"\") = %q, want \"high\" from .claude/settings.json", got)
+	}
+}
+
+func TestResolveEffort_LocalSettingsOutrankShared(t *testing.T) {
+	isolateSettings(t)
+	writeSettings(t, filepath.Join(".claude", "settings.json"), `{"effortLevel":"high"}`)
+	writeSettings(t, filepath.Join(".claude", "settings.local.json"), `{"effortLevel":"xhigh"}`)
+
+	// Same precedence the claude CLI applies: local overrides shared.
+	if got := config.ResolveEffort(""); got != "xhigh" {
+		t.Errorf("ResolveEffort(\"\") = %q, want \"xhigh\" from settings.local.json", got)
+	}
+}
+
+func TestResolveEffort_ProjectSettingsOutrankUser(t *testing.T) {
+	isolateSettings(t)
+	writeSettings(t, filepath.Join(".claude", "settings.json"), `{"effortLevel":"low"}`)
+	writeSettings(t, filepath.Join(os.Getenv("HOME"), ".claude", "settings.json"), `{"effortLevel":"max"}`)
+
+	// The whole chain has to be walked in the CLI's order, not just "first file
+	// that exists": a repo that pins an effort level overrides the user's global
+	// one, so reading ~/.claude first would report a level the CLI is not using.
+	if got := config.ResolveEffort(""); got != "low" {
+		t.Errorf("ResolveEffort(\"\") = %q, want \"low\" — project settings outrank ~/.claude", got)
+	}
+}
+
+func TestResolveEffort_FallsBackToUserSettings(t *testing.T) {
+	isolateSettings(t)
+	writeSettings(t, filepath.Join(os.Getenv("HOME"), ".claude", "settings.json"), `{"effortLevel":"medium"}`)
+
+	if got := config.ResolveEffort(""); got != "medium" {
+		t.Errorf("ResolveEffort(\"\") = %q, want \"medium\" from ~/.claude/settings.json", got)
+	}
+}
+
+func TestResolveEffort_SkipsFilesWithoutTheKey(t *testing.T) {
+	isolateSettings(t)
+	// A settings file that exists but configures something else must not stop
+	// the walk — the next source down still applies.
+	writeSettings(t, filepath.Join(".claude", "settings.json"), `{"model":"claude-opus-4-8"}`)
+	writeSettings(t, filepath.Join(os.Getenv("HOME"), ".claude", "settings.json"), `{"effortLevel":"low"}`)
+
+	if got := config.ResolveEffort(""); got != "low" {
+		t.Errorf("ResolveEffort(\"\") = %q, want \"low\" — a file without effortLevel should not end the walk", got)
+	}
+}
+
+func TestResolveEffort_SkipsMalformedSettings(t *testing.T) {
+	isolateSettings(t)
+	// Half-written or hand-broken JSON is not fatal.
+	writeSettings(t, filepath.Join(".claude", "settings.json"), `{"effortLevel": `)
+	writeSettings(t, filepath.Join(os.Getenv("HOME"), ".claude", "settings.json"), `{"effortLevel":"max"}`)
+
+	if got := config.ResolveEffort(""); got != "max" {
+		t.Errorf("ResolveEffort(\"\") = %q, want \"max\" — malformed JSON should be skipped, not fatal", got)
+	}
+}
+
+func TestResolveEffort_EmptyWhenNothingConfigured(t *testing.T) {
+	isolateSettings(t)
+
+	// Nothing configures a level, so the CLI picks for itself and Ralph must
+	// say so rather than invent one. The TUI renders this as "-".
+	if got := config.ResolveEffort(""); got != "" {
+		t.Errorf("ResolveEffort(\"\") = %q, want \"\" when no source configures a level", got)
+	}
+}
+
+// writeTranscript writes a session transcript at the path the claude CLI uses,
+// under a project directory whose name does not matter — TranscriptEffort finds
+// it by session ID.
+func writeTranscript(t *testing.T, sessionID, body string) {
+	t.Helper()
+
+	dir := filepath.Join(os.Getenv("HOME"), ".claude", "projects", "-tmp-project")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", dir, err)
+	}
+	path := filepath.Join(dir, sessionID+".jsonl")
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile(%s): %v", path, err)
+	}
+}
+
+const testSessionID = "a50b7b11-7b8d-44a7-bdf5-0433d84f3fb1"
+
+func TestTranscriptEffort_ReadsRecordedLevel(t *testing.T) {
+	isolateSettings(t)
+	writeTranscript(t, testSessionID, `{"type":"user","message":{"role":"user"}}
+{"type":"assistant","effort":"xhigh","message":{"model":"claude-opus-5"}}
+`)
+
+	if got := config.TranscriptEffort(testSessionID); got != "xhigh" {
+		t.Errorf("TranscriptEffort = %q, want \"xhigh\" from the assistant record", got)
+	}
+}
+
+func TestTranscriptEffort_LastRecordWins(t *testing.T) {
+	isolateSettings(t)
+	// A --resume'd session keeps earlier iterations' records in the same file;
+	// the newest level is the one in force.
+	writeTranscript(t, testSessionID, `{"type":"assistant","effort":"low"}
+{"type":"assistant","effort":"max"}
+`)
+
+	if got := config.TranscriptEffort(testSessionID); got != "max" {
+		t.Errorf("TranscriptEffort = %q, want \"max\" — the newest record wins", got)
+	}
+}
+
+func TestTranscriptEffort_ToleratesHalfWrittenTail(t *testing.T) {
+	isolateSettings(t)
+	// The CLI appends to this file while Ralph reads it, so the final record
+	// can be truncated mid-write. Everything decoded before it still counts.
+	writeTranscript(t, testSessionID, `{"type":"assistant","effort":"high"}
+{"type":"assistant","effo`)
+
+	if got := config.TranscriptEffort(testSessionID); got != "high" {
+		t.Errorf("TranscriptEffort = %q, want \"high\" — a truncated trailing record should not discard earlier ones", got)
+	}
+}
+
+func TestTranscriptEffort_EmptyBeforeFirstAssistantRecord(t *testing.T) {
+	isolateSettings(t)
+	// Only assistant records carry the level, so early in a session there is
+	// nothing to read yet. The caller retries rather than treating this as
+	// "no effort configured".
+	writeTranscript(t, testSessionID, `{"type":"user","message":{"role":"user"}}
+`)
+
+	if got := config.TranscriptEffort(testSessionID); got != "" {
+		t.Errorf("TranscriptEffort = %q, want \"\" before the first assistant record", got)
+	}
+}
+
+func TestTranscriptEffort_EmptyWhenNoTranscript(t *testing.T) {
+	isolateSettings(t)
+
+	if got := config.TranscriptEffort(testSessionID); got != "" {
+		t.Errorf("TranscriptEffort = %q, want \"\" when no transcript exists for the session", got)
+	}
+}
+
+func TestTranscriptEffort_RejectsNonSessionIDs(t *testing.T) {
+	isolateSettings(t)
+	writeTranscript(t, testSessionID, `{"type":"assistant","effort":"max"}`+"\n")
+
+	// The ID is interpolated into a glob and a path, so anything not shaped
+	// like the CLI's UUID is refused outright — a wildcard must not match the
+	// real transcript, and a traversal must not reach outside the projects dir.
+	for _, id := range []string{"", "*", "../../etc/passwd", "a50b7b11/../../x"} {
+		if got := config.TranscriptEffort(id); got != "" {
+			t.Errorf("TranscriptEffort(%q) = %q, want \"\" — non-UUID session IDs must be refused", id, got)
+		}
+	}
+}

--- a/tests/parser_test.go
+++ b/tests/parser_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/cloudosai/ralph-go/internal/parser"
 )
@@ -572,8 +573,103 @@ func TestToolUseTruncation(t *testing.T) {
 		t.Fatalf("Expected 1 tool use, got %d", len(content.ToolUses))
 	}
 
-	if len(content.ToolUses[0].InputJSON) > 150 {
-		t.Errorf("Expected InputJSON to be truncated to 150 chars, got %d", len(content.ToolUses[0].InputJSON))
+	inputJSON := content.ToolUses[0].InputJSON
+	if got := utf8.RuneCountInString(inputJSON); got != 150+len("...") {
+		t.Errorf("Expected InputJSON truncated to 150 runes + ellipsis (%d), got %d runes",
+			150+len("..."), got)
+	}
+	if !strings.HasSuffix(inputJSON, "...") {
+		t.Errorf("Expected truncated InputJSON to end with an ellipsis, got %q", inputJSON)
+	}
+}
+
+// multibyteCommand returns a Bash command whose ASCII prefix is exactly
+// prefixLen characters long, followed by 3-byte CJK runes. Truncating it at any
+// character offset >= prefixLen therefore lands inside a multibyte rune when the
+// cut is made by byte index instead of by rune.
+func multibyteCommand(prefixLen int) string {
+	return strings.Repeat("a", prefixLen) + "日本語のコマンド"
+}
+
+// TestExtractFilePathFromInputRuneSafe guards the Bash-command truncation in
+// ExtractFilePathFromInput against splitting a multibyte rune. The result is
+// user-visible: cmd/ralph/main.go appends it to the tool row shown in the TUI,
+// so a split rune renders as mojibake.
+func TestExtractFilePathFromInputRuneSafe(t *testing.T) {
+	// 48 ASCII chars + CJK puts a 3-byte rune across the 50-character cut.
+	cmd := multibyteCommand(48)
+	got := parser.ExtractFilePathFromInput(map[string]interface{}{"command": cmd})
+
+	if !utf8.ValidString(got) {
+		t.Errorf("Expected valid UTF-8 after truncation, got %q", got)
+	}
+	want := string([]rune(cmd)[:50]) + "..."
+	if got != want {
+		t.Errorf("Expected first 50 runes + ellipsis\n want %q\n  got %q", want, got)
+	}
+	if n := utf8.RuneCountInString(got); n != 53 {
+		t.Errorf("Expected 53 runes (50 + ellipsis), got %d", n)
+	}
+}
+
+// TestToolUseInputJSONRuneSafe guards the 150-character tool-input preview
+// against splitting a multibyte rune.
+func TestToolUseInputJSONRuneSafe(t *testing.T) {
+	p := parser.NewParser()
+
+	// MarshalIndent wraps the command in 19 characters ({\n  "command": "…"\n}),
+	// so a 130-char ASCII prefix followed by CJK puts the 150th character — and
+	// byte offset 150 — inside a 3-byte rune.
+	line := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"Bash","input":{"command":"` +
+		multibyteCommand(130) + `"}}]}}`
+
+	content := p.ExtractContent(p.ParseLine(line))
+	if len(content.ToolUses) != 1 {
+		t.Fatalf("Expected 1 tool use, got %d", len(content.ToolUses))
+	}
+
+	inputJSON := content.ToolUses[0].InputJSON
+	if !utf8.ValidString(inputJSON) {
+		t.Errorf("Expected valid UTF-8 after truncation, got %q", inputJSON)
+	}
+	if n := utf8.RuneCountInString(inputJSON); n != 153 {
+		t.Errorf("Expected 153 runes (150 + ellipsis), got %d", n)
+	}
+}
+
+// TestToolTitleRuneSafe locks in rune-safe truncation for the tool titles built
+// from search patterns, Bash commands, and fetch URLs.
+func TestToolTitleRuneSafe(t *testing.T) {
+	p := parser.NewParser()
+
+	tests := []struct {
+		name     string
+		toolName string
+		key      string
+	}{
+		{"Bash command", "Bash", "command"},
+		{"Grep pattern", "Grep", "pattern"},
+		{"WebFetch url", "WebFetch", "url"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			line := `{"type":"assistant","message":{"content":[{"type":"tool_use","name":"` +
+				tt.toolName + `","input":{"` + tt.key + `":"` + multibyteCommand(48) + `"}}]}}`
+
+			content := p.ExtractContent(p.ParseLine(line))
+			if len(content.ToolUses) != 1 {
+				t.Fatalf("Expected 1 tool use, got %d", len(content.ToolUses))
+			}
+
+			title := content.ToolUses[0].Title
+			if !utf8.ValidString(title) {
+				t.Errorf("Expected valid UTF-8 title, got %q", title)
+			}
+			if !strings.HasSuffix(title, "...") {
+				t.Errorf("Expected truncated title to end with an ellipsis, got %q", title)
+			}
+		})
 	}
 }
 

--- a/tests/parser_test.go
+++ b/tests/parser_test.go
@@ -1,6 +1,8 @@
 package tests
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -883,92 +885,93 @@ func TestSessionIDFieldParsed(t *testing.T) {
 	}
 }
 
-func TestExtractTaskReference(t *testing.T) {
+func TestGetModel(t *testing.T) {
 	p := parser.NewParser()
 
 	tests := []struct {
-		name       string
-		input      string
-		expectNil  bool
-		expectNum  int
-		expectDesc string
+		name     string
+		line     string
+		expected string
 	}{
 		{
-			"no task reference",
-			"Just a regular message about coding",
-			true, 0, "",
+			"system init carries model at top level",
+			`{"type":"system","subtype":"init","session_id":"s1","model":"claude-sonnet-4-6"}`,
+			"claude-sonnet-4-6",
 		},
 		{
-			"empty string",
+			"assistant message carries model under message",
+			`{"type":"assistant","message":{"id":"msg_01","model":"claude-opus-4-8","content":[]}}`,
+			"claude-opus-4-8",
+		},
+		{
+			"message.model wins over top-level model",
+			`{"type":"assistant","model":"claude-sonnet-4-6","message":{"model":"claude-opus-4-8","content":[]}}`,
+			"claude-opus-4-8",
+		},
+		{
+			"top-level model used when message.model is empty",
+			`{"type":"assistant","model":"claude-sonnet-4-6","message":{"content":[]}}`,
+			"claude-sonnet-4-6",
+		},
+		{
+			"no model anywhere",
+			`{"type":"assistant","message":{"id":"msg_01","content":[]}}`,
 			"",
-			true, 0, "",
 		},
 		{
-			"simple TASK N",
-			"I will implement TASK 6 now",
-			false, 6, "",
+			"system message without model",
+			`{"type":"system","subtype":"init","session_id":"s1"}`,
+			"",
 		},
 		{
-			"lowercase task n",
-			"working on task 3 implementation",
-			false, 3, "",
-		},
-		{
-			"TASK with description",
-			"## TASK 6: Track IMPLEMENTATION_PLAN.md Phase/Task",
-			false, 6, "Track IMPLEMENTATION_PLAN.md Phase/Task",
-		},
-		{
-			"TASK with description and status bracket",
-			"## TASK 1: Replace Control Panel with Hotkey Bar [HIGH PRIORITY]",
-			false, 1, "Replace Control Panel with Hotkey Bar",
-		},
-		{
-			"multiple tasks picks last",
-			"After completing TASK 3, I will start TASK 5",
-			false, 5, "",
-		},
-		{
-			"IMPLEMENTATION_PLAN.md content with description",
-			"TASK 2: Fix Message Truncation (spec item 1)",
-			false, 2, "Fix Message Truncation (spec item 1)",
-		},
-		{
-			"task number zero ignored",
-			"TASK 0 should not match",
-			true, 0, "",
-		},
-		{
-			"mixed case",
-			"Let me work on Task 7 next",
-			false, 7, "",
-		},
-		{
-			"task in tool result content",
-			"Read IMPLEMENTATION_PLAN.md:\n## TASK 4: Fix Visual Artifacts [MEDIUM PRIORITY]\n**Status: DONE**",
-			false, 4, "Fix Visual Artifacts",
+			"result message without model",
+			`{"type":"result","total_cost_usd":0.001}`,
+			"",
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ref := p.ExtractTaskReference(tt.input)
-			if tt.expectNil {
-				if ref != nil {
-					t.Errorf("Expected nil, got Task %d (desc: %q)", ref.Number, ref.Description)
-				}
-				return
+			msg := p.ParseLine(tt.line)
+			if msg == nil {
+				t.Fatal("Expected non-nil result")
 			}
-			if ref == nil {
-				t.Fatal("Expected non-nil TaskReference")
-			}
-			if ref.Number != tt.expectNum {
-				t.Errorf("Expected number %d, got %d", tt.expectNum, ref.Number)
-			}
-			if ref.Description != tt.expectDesc {
-				t.Errorf("Expected description %q, got %q", tt.expectDesc, ref.Description)
+			result := p.GetModel(msg)
+			if result != tt.expected {
+				t.Errorf("Expected model %q, got %q", tt.expected, result)
 			}
 		})
+	}
+}
+
+func TestGetModelNilMessage(t *testing.T) {
+	p := parser.NewParser()
+	if result := p.GetModel(nil); result != "" {
+		t.Errorf("Expected empty string for nil message, got %q", result)
+	}
+}
+
+// TestGetModelFromFixtureInitLine reads the real recorded session's first line —
+// a genuine system/init emitted by the Claude CLI — to prove GetModel picks up
+// the top-level model field as it actually appears on the wire.
+func TestGetModelFromFixtureInitLine(t *testing.T) {
+	p := parser.NewParser()
+
+	data, err := os.ReadFile(filepath.Join("fixtures", "subagent_cost_session.json"))
+	if err != nil {
+		t.Fatalf("Failed to read fixture: %v", err)
+	}
+
+	firstLine := strings.SplitN(string(data), "\n", 2)[0]
+	msg := p.ParseLine(firstLine)
+	if msg == nil {
+		t.Fatal("Expected first fixture line to parse")
+	}
+	if msg.Type != parser.MessageTypeSystem {
+		t.Fatalf("Expected first fixture line to be a system message, got %q", msg.Type)
+	}
+	if got := p.GetModel(msg); got != "claude-sonnet-4-6" {
+		t.Errorf("Expected model %q from fixture init line, got %q", "claude-sonnet-4-6", got)
 	}
 }
 

--- a/tests/stats_test.go
+++ b/tests/stats_test.go
@@ -115,11 +115,6 @@ func TestTotalTokens(t *testing.T) {
 	}
 }
 
-
-
-
-
-
 func TestAddUsage_ZeroValues(t *testing.T) {
 	s := stats.NewTokenStats()
 	s.AddUsage(0, 0, 0, 0)
@@ -178,8 +173,6 @@ func TestAddCost_SmallValues(t *testing.T) {
 	}
 }
 
-
-
 func TestAccumulationMatchesPython(t *testing.T) {
 	// Test that accumulation matches the Python version behavior
 	s := stats.NewTokenStats()
@@ -230,8 +223,6 @@ func TestAccumulationMatchesPython(t *testing.T) {
 	}
 }
 
-
-
 func TestTotalTokensCount_UpdatedAfterAddUsage(t *testing.T) {
 	s := stats.NewTokenStats()
 
@@ -246,7 +237,6 @@ func TestTotalTokensCount_UpdatedAfterAddUsage(t *testing.T) {
 		t.Errorf("TotalTokensCount (%d) should match TotalTokens() (%d)", s.TotalTokensCount, s.TotalTokens())
 	}
 }
-
 
 func TestEstimateCostFromTokens(t *testing.T) {
 	tests := []struct {
@@ -587,17 +577,17 @@ func TestFlushCheckpoint(t *testing.T) {
 
 	ts := time.Now().UTC().Format(time.RFC3339)
 	p := stats.CheckpointParams{
-		LoopID:            "abc123-1",
-		SessionID:         "abc123",
-		Owner:             "testowner",
-		Repo:              "testrepo",
-		Branch:            "main",
-		DeltaCost:         0.05,
-		DeltaInputTokens:  1000,
-		DeltaOutputTokens: 500,
+		LoopID:             "abc123-1",
+		SessionID:          "abc123",
+		Owner:              "testowner",
+		Repo:               "testrepo",
+		Branch:             "main",
+		DeltaCost:          0.05,
+		DeltaInputTokens:   1000,
+		DeltaOutputTokens:  500,
 		DeltaCacheCreation: 200,
-		DeltaCacheRead:    100,
-		Timestamp:         ts,
+		DeltaCacheRead:     100,
+		Timestamp:          ts,
 	}
 
 	if err := stats.FlushCheckpoint(db, p); err != nil {
@@ -879,7 +869,6 @@ func TestGetGitContext(t *testing.T) {
 	}
 }
 
-
 func TestQueryRollingHourCost_NilDB(t *testing.T) {
 	cost, err := stats.QueryRollingHourCost(nil, "", "")
 	if err != nil {
@@ -1002,7 +991,6 @@ func TestQueryRollingWakeTime_FallbackSingleLargeCheckpoint(t *testing.T) {
 		t.Errorf("Expected fallback wake time ~%v, got %v (diff=%v)", expectedWake, wakeTime, diff)
 	}
 }
-
 
 func TestReconcileCostThreadSafe(t *testing.T) {
 	s := stats.NewTokenStats()

--- a/tests/stats_test.go
+++ b/tests/stats_test.go
@@ -290,6 +290,35 @@ func TestEstimateCostFromTokens(t *testing.T) {
 	}
 }
 
+func TestModelTier(t *testing.T) {
+	tests := []struct {
+		name  string
+		model string
+		want  string
+	}{
+		{"opus", "claude-opus-4-8", "opus"},
+		{"sonnet", "claude-sonnet-4-6", "sonnet"},
+		{"haiku", "claude-haiku-4-5", "haiku"},
+		{"fable", "claude-fable-5", "fable"},
+		{"opus dated snapshot", "claude-opus-4-5-20251101", "opus"},
+		{"bedrock prefix", "anthropic.claude-sonnet-4-6", "sonnet"},
+		{"mixed case", "Claude-OPUS-4-8", "opus"},
+		{"uppercase bare tier", "HAIKU", "haiku"},
+		{"bare tier name without claude prefix", "sonnet", "sonnet"},
+		{"empty", "", ""},
+		{"unknown", "gpt-4", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stats.ModelTier(tt.model)
+			if got != tt.want {
+				t.Errorf("ModelTier(%q) = %q, want %q", tt.model, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPricingForModel(t *testing.T) {
 	tests := []struct {
 		name  string

--- a/tests/tmux_test.go
+++ b/tests/tmux_test.go
@@ -3,6 +3,7 @@ package tests
 import (
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/cloudosai/ralph-go/internal/tmux"
@@ -154,8 +155,8 @@ func TestStatusBarNilSafe(t *testing.T) {
 
 // TestFormatStatusRight tests the status bar format string
 func TestFormatStatusRight(t *testing.T) {
-	result := tmux.FormatStatusRight("ralph", "main", "1/5", "07:18:00")
-	expected := "[ralph | main | loop: 1/5, uptime: 07:18:00]"
+	result := tmux.FormatStatusRight("ralph", "main", "1/5", "12.3k", "07:18:00")
+	expected := "[ralph | main | loop: 1/5, tokens: 12.3k, elapsed: 07:18:00]"
 	if result != expected {
 		t.Errorf("FormatStatusRight() = %q, want %q", result, expected)
 	}
@@ -163,12 +164,79 @@ func TestFormatStatusRight(t *testing.T) {
 
 // TestFormatStatusRight_ZeroValues tests formatting with zero/default values
 func TestFormatStatusRight_ZeroValues(t *testing.T) {
-	result := tmux.FormatStatusRight("", "", "0/0", "00:00:00")
+	result := tmux.FormatStatusRight("", "", "0/0", "0", "00:00:00")
 	if result == "" {
 		t.Error("FormatStatusRight should return non-empty string for zero values")
 	}
-	expected := "[ |  | loop: 0/0, uptime: 00:00:00]"
+	expected := "[ |  | loop: 0/0, tokens: 0, elapsed: 00:00:00]"
 	if result != expected {
 		t.Errorf("FormatStatusRight() = %q, want %q", result, expected)
+	}
+}
+
+// TestFormatStatusRight_OmitsEmptyFields tests that an empty tokenDisplay or
+// timeDisplay drops the whole field instead of rendering a dangling label, and
+// that the surviving fields keep the order loop, tokens, elapsed.
+func TestFormatStatusRight_OmitsEmptyFields(t *testing.T) {
+	tests := []struct {
+		name        string
+		repo        string
+		branch      string
+		loopDisplay string
+		tokenDispl  string
+		timeDisplay string
+		expected    string
+	}{
+		{
+			name:        "all fields present",
+			repo:        "ralph",
+			branch:      "main",
+			loopDisplay: "2/5",
+			tokenDispl:  "1.2m",
+			timeDisplay: "00:04:07",
+			expected:    "[ralph | main | loop: 2/5, tokens: 1.2m, elapsed: 00:04:07]",
+		},
+		{
+			name:        "tokens omitted",
+			repo:        "ralph",
+			branch:      "main",
+			loopDisplay: "2/5",
+			tokenDispl:  "",
+			timeDisplay: "00:04:07",
+			expected:    "[ralph | main | loop: 2/5, elapsed: 00:04:07]",
+		},
+		{
+			name:        "elapsed omitted",
+			repo:        "ralph",
+			branch:      "main",
+			loopDisplay: "2/5",
+			tokenDispl:  "1.2m",
+			timeDisplay: "",
+			expected:    "[ralph | main | loop: 2/5, tokens: 1.2m]",
+		},
+		{
+			name:        "both omitted (hibernate)",
+			repo:        "ralph",
+			branch:      "main",
+			loopDisplay: "RATE LIMITED 💤 03:30",
+			tokenDispl:  "",
+			timeDisplay: "",
+			expected:    "[ralph | main | loop: RATE LIMITED 💤 03:30]",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := tmux.FormatStatusRight(tt.repo, tt.branch, tt.loopDisplay, tt.tokenDispl, tt.timeDisplay)
+			if result != tt.expected {
+				t.Errorf("FormatStatusRight() = %q, want %q", result, tt.expected)
+			}
+			if tt.tokenDispl == "" && strings.Contains(result, "tokens:") {
+				t.Errorf("FormatStatusRight() = %q, want no %q label", result, "tokens:")
+			}
+			if tt.timeDisplay == "" && strings.Contains(result, "elapsed:") {
+				t.Errorf("FormatStatusRight() = %q, want no %q label", result, "elapsed:")
+			}
+		})
 	}
 }

--- a/tests/tui_test.go
+++ b/tests/tui_test.go
@@ -806,14 +806,16 @@ func TestViewportScrollPreservedOnTick(t *testing.T) {
 	}
 }
 
-// TestModeDisplayDefault tests that the mode row shows "-" by default
+// TestModeDisplayDefault tests that the mode row renders by default in the
+// Model Details panel. Note "Model:" does not contain the substring "Mode:",
+// so this assertion is specific to the mode row.
 func TestModeDisplayDefault(t *testing.T) {
 	model := tui.NewModel()
 	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
 
 	view := model.View()
-	if !strings.Contains(view, "Current Mode:") {
-		t.Error("View should contain 'Current Mode:' label")
+	if !strings.Contains(view, "Mode:") {
+		t.Error("View should contain 'Mode:' label")
 	}
 }
 
@@ -913,7 +915,7 @@ func TestQuitHotkeyAlwaysHighlighted(t *testing.T) {
 	}
 }
 
-// TestCurrentModeDisplayFormat tests the "Current Mode:" display format
+// TestCurrentModeDisplayFormat tests the "Mode: <value>" display format
 func TestCurrentModeDisplayFormat(t *testing.T) {
 	model := tui.NewModel()
 	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
@@ -924,8 +926,8 @@ func TestCurrentModeDisplayFormat(t *testing.T) {
 	model, _ = updateModel(model, modeMsg)
 
 	view := model.View()
-	if !strings.Contains(view, "Current Mode:") {
-		t.Error("View should contain 'Current Mode:' label")
+	if !strings.Contains(view, "Mode:") {
+		t.Error("View should contain 'Mode:' label")
 	}
 	if !strings.Contains(view, "Planning") {
 		t.Error("View should display the mode")
@@ -969,32 +971,6 @@ func TestSetTmuxStatusBar(t *testing.T) {
 	view := model.View()
 	if view == "" {
 		t.Error("View should render with inactive tmux status bar")
-	}
-}
-
-// TestSendCompletedTasksUpdateCmd tests the SendCompletedTasksUpdate helper command
-func TestSendCompletedTasksUpdateCmd(t *testing.T) {
-	cmd := tui.SendCompletedTasksUpdate(3, 8)
-
-	if cmd == nil {
-		t.Error("SendCompletedTasksUpdate should return a command")
-	}
-
-	result := cmd()
-	if result == nil {
-		t.Error("Command should return a completed tasks update message")
-	}
-}
-
-// TestSetCompletedTasks tests the SetCompletedTasks setter method
-func TestSetCompletedTasks(t *testing.T) {
-	model := tui.NewModel()
-	model.SetCompletedTasks(5, 10)
-	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
-
-	view := model.View()
-	if !strings.Contains(view, "5/10") {
-		t.Error("View should show '5/10' after SetCompletedTasks")
 	}
 }
 
@@ -1371,29 +1347,6 @@ func TestRalphLoopDetailsTitle(t *testing.T) {
 	view := model.View()
 	if !strings.Contains(view, "Ralph Loop Details") {
 		t.Error("View should contain 'Ralph Loop Details' title (renamed from 'Ralph Details')")
-	}
-}
-
-// ============================================================================
-// Tests: Current Task Display in Footer
-// ============================================================================
-
-// TestCurrentTaskDisplayedInFooter tests that the currentTask field renders in the footer
-func TestCurrentTaskDisplayedInFooter(t *testing.T) {
-	model := tui.NewModel()
-	model.SetCurrentTask("#6 Refactor config")
-	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
-
-	view := model.View()
-	if !strings.Contains(view, "Current Task:") {
-		t.Error("View should contain 'Current Task:' label")
-	}
-	// The quarter-width Task Progress panel word-wraps the task text, so
-	// assert the segments rather than one contiguous line.
-	for _, segment := range []string{"#6 Refactor", "config"} {
-		if !strings.Contains(view, segment) {
-			t.Errorf("View should display the current task text segment %q", segment)
-		}
 	}
 }
 
@@ -1943,6 +1896,144 @@ func TestDeletePlanHotkeyInHotkeyBar(t *testing.T) {
 	view := model.View()
 	if !strings.Contains(view, "(D)") {
 		t.Error("Footer hotkey bar should show (D)elete plan hint")
+	}
+}
+
+// ============================================================================
+// Tests: Model Details Footer Panel
+//
+// The fourth footer panel shows what the loop is actually running with:
+// "Model:", "Effort:" and "Mode:" rows. Known model tiers collapse to their
+// short name, unknown ids render verbatim, and an empty flag reads "default"
+// (i.e. whatever the claude CLI resolves on its own).
+// ============================================================================
+
+// setupModelDetailsModel builds a ready model with the given --model/--effort
+// flag values. The footer panels are (width-8)/4 wide, so a wide terminal keeps
+// short values on one line and avoids word-wrap-sensitive assertions.
+func setupModelDetailsModel(model, effort string) tui.Model {
+	m := tui.NewModel()
+	m.SetModelInfo(model, effort)
+	m, _ = updateModel(m, tea.WindowSizeMsg{Width: 200, Height: 40})
+	return m
+}
+
+// TestModelDetailsPanelTitleRendered tests that the fourth footer panel is titled
+// "Model Details".
+func TestModelDetailsPanelTitleRendered(t *testing.T) {
+	model := setupModelDetailsModel("", "")
+
+	view := model.View()
+	if !strings.Contains(view, "Model Details") {
+		t.Error("View should contain the 'Model Details' panel title")
+	}
+}
+
+// TestModelDetailsShowsOpusTierAndEffort tests that a full opus model id collapses
+// to its tier name and the effort level is shown alongside it.
+func TestModelDetailsShowsOpusTierAndEffort(t *testing.T) {
+	model := setupModelDetailsModel("claude-opus-4-8", "high")
+
+	view := model.View()
+	for _, want := range []string{"Model:", "opus", "Effort:", "high"} {
+		if !strings.Contains(view, want) {
+			t.Errorf("View should contain %q in the Model Details panel", want)
+		}
+	}
+	// The verbose id should be collapsed, not printed in full.
+	if strings.Contains(view, "claude-opus-4-8") {
+		t.Error("View should collapse 'claude-opus-4-8' to the tier name 'opus'")
+	}
+}
+
+// TestModelDetailsCollapsesSonnetTier tests the sonnet tier collapse and that an
+// unset effort flag reads "default".
+func TestModelDetailsCollapsesSonnetTier(t *testing.T) {
+	model := setupModelDetailsModel("claude-sonnet-4-6", "")
+
+	view := model.View()
+	if !strings.Contains(view, "sonnet") {
+		t.Error("View should collapse 'claude-sonnet-4-6' to the tier name 'sonnet'")
+	}
+	if !strings.Contains(view, "default") {
+		t.Error("View should show 'default' effort when --effort was not passed")
+	}
+}
+
+// TestModelDetailsEmptyFlagsShowDefault tests that an unset model and effort both
+// render as "default" (the claude CLI decides).
+func TestModelDetailsEmptyFlagsShowDefault(t *testing.T) {
+	model := setupModelDetailsModel("", "")
+
+	view := model.View()
+	if !strings.Contains(view, "Model:") || !strings.Contains(view, "Effort:") {
+		t.Fatal("View should contain the 'Model:' and 'Effort:' rows")
+	}
+	// "default" is only ever produced by the model and effort rows, so both
+	// rows falling back means exactly two occurrences.
+	if got := strings.Count(view, "default"); got != 2 {
+		t.Errorf("Expected both the model and effort rows to read 'default' (2 occurrences), got %d", got)
+	}
+}
+
+// TestModelDetailsUnknownModelRendersVerbatim tests that a model id with no known
+// tier is shown as-is.
+func TestModelDetailsUnknownModelRendersVerbatim(t *testing.T) {
+	model := setupModelDetailsModel("zeta-9", "low")
+
+	view := model.View()
+	if !strings.Contains(view, "zeta-9") {
+		t.Error("View should render an unrecognized model id verbatim")
+	}
+	if strings.Contains(view, "Model: default") {
+		t.Error("An unrecognized model id should not fall back to 'default'")
+	}
+}
+
+// TestModelDetailsEffortLowercased tests that the effort level is lowercased for display.
+func TestModelDetailsEffortLowercased(t *testing.T) {
+	model := setupModelDetailsModel("", "XHIGH")
+
+	view := model.View()
+	if !strings.Contains(view, "xhigh") {
+		t.Error("View should lowercase the effort level ('XHIGH' -> 'xhigh')")
+	}
+	if strings.Contains(view, "XHIGH") {
+		t.Error("View should not show the raw uppercase effort level")
+	}
+}
+
+// TestModelDetailsStreamModelOverridesFlag tests that the effective model reported
+// by the stream overrides the model set from the --model flag.
+func TestModelDetailsStreamModelOverridesFlag(t *testing.T) {
+	model := setupModelDetailsModel("claude-opus-4-8", "high")
+
+	cmd := tui.SendModelUpdate("claude-haiku-4-5")
+	model, _ = updateModel(model, cmd())
+
+	view := model.View()
+	if !strings.Contains(view, "haiku") {
+		t.Error("View should show 'haiku' after the stream reports the effective model")
+	}
+	if strings.Contains(view, "opus") {
+		t.Error("View should no longer show the flag model 'opus' after a stream model update")
+	}
+}
+
+// TestModelDetailsEmptyStreamModelIgnored tests that an empty model update does not
+// clobber the already-known model.
+func TestModelDetailsEmptyStreamModelIgnored(t *testing.T) {
+	model := setupModelDetailsModel("claude-opus-4-8", "high")
+
+	cmd := tui.SendModelUpdate("")
+	model, _ = updateModel(model, cmd())
+
+	view := model.View()
+	if !strings.Contains(view, "opus") {
+		t.Error("An empty model update should not clear the previously-set model")
+	}
+	if strings.Contains(view, "Model: default") {
+		t.Error("An empty model update should not reset the model row to 'default'")
 	}
 }
 

--- a/tests/tui_test.go
+++ b/tests/tui_test.go
@@ -1652,23 +1652,31 @@ func TestHibernateRoleStyle(t *testing.T) {
 	}
 }
 
-// TestHibernateMsgUpdate tests that hibernateMsg updates the model's hibernate state
-func TestHibernateMsgUpdate(t *testing.T) {
+// TestHibernateStateFollowsLoop tests that the TUI's rate-limit state is read
+// straight off the loop rather than tracked separately: the same model shows no
+// rate limit before the loop hibernates and shows one immediately after, with no
+// message sent to the TUI in between.
+func TestHibernateStateFollowsLoop(t *testing.T) {
 	model := tui.NewModel()
+	l := loop.New(loop.Config{Iterations: 5, Prompt: "test"})
+	model.SetLoop(l)
 	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
 
-	// Send hibernate message
-	hibernateUntil := time.Now().Add(5 * time.Minute)
-	hibernateCmd := tui.SendHibernate(hibernateUntil)
-	hibernateMsg := hibernateCmd()
+	// Before: the loop is not hibernating, so nothing claims a rate limit
+	if strings.Contains(model.View(), "RATE LIMITED") {
+		t.Fatal("Precondition: view should not show 'RATE LIMITED' before the loop hibernates")
+	}
 
-	model, _ = updateModel(model, hibernateMsg)
+	// When: the loop hibernates (no TUI message involved)
+	l.Hibernate(time.Now().Add(5 * time.Minute))
 
-	// After tick, the view should update (we can't directly check internal state,
-	// but we can verify the model renders properly)
+	// Then: the very next render picks the state up from the loop
 	view := model.View()
 	if view == "" || view == "Goodbye!\n" {
-		t.Error("Model should render properly after hibernate message")
+		t.Fatalf("Model should still render properly while hibernating, got: %q", view)
+	}
+	if !strings.Contains(view, "RATE LIMITED") {
+		t.Error("View should contain 'RATE LIMITED' once the loop is hibernating")
 	}
 }
 
@@ -1681,11 +1689,6 @@ func TestHibernateDisplayShowsRateLimited(t *testing.T) {
 
 	// Hibernate the loop
 	l.Hibernate(time.Now().Add(5 * time.Minute))
-
-	// Send hibernate message to TUI
-	hibernateCmd := tui.SendHibernate(time.Now().Add(5 * time.Minute))
-	hibernateMsg := hibernateCmd()
-	model, _ = updateModel(model, hibernateMsg)
 
 	view := model.View()
 
@@ -1703,13 +1706,7 @@ func TestHibernateDisplayShowsCountdown(t *testing.T) {
 	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
 
 	// Hibernate for 5 minutes (300 seconds)
-	hibernateUntil := time.Now().Add(5 * time.Minute)
-	l.Hibernate(hibernateUntil)
-
-	// Send hibernate message to TUI
-	hibernateCmd := tui.SendHibernate(hibernateUntil)
-	hibernateMsg := hibernateCmd()
-	model, _ = updateModel(model, hibernateMsg)
+	l.Hibernate(time.Now().Add(5 * time.Minute))
 
 	view := model.View()
 
@@ -1732,11 +1729,6 @@ func TestHibernateRKeyWake(t *testing.T) {
 
 	// Hibernate the loop
 	l.Hibernate(time.Now().Add(10 * time.Second))
-
-	// Send hibernate message to TUI
-	hibernateCmd := tui.SendHibernate(time.Now().Add(10 * time.Second))
-	hibernateMsg := hibernateCmd()
-	model, _ = updateModel(model, hibernateMsg)
 
 	// Verify loop is hibernating
 	if !l.IsHibernating() {
@@ -1764,22 +1756,6 @@ func TestHibernateMessageInActivityFeed(t *testing.T) {
 	// Should show 💤 emoji in activity feed
 	if !strings.Contains(view, "💤") {
 		t.Error("Activity feed should show 💤 emoji for hibernate messages")
-	}
-}
-
-// TestSendHibernateCmd tests the SendHibernate helper function
-func TestSendHibernateCmd(t *testing.T) {
-	until := time.Now().Add(5 * time.Minute)
-	cmd := tui.SendHibernate(until)
-
-	if cmd == nil {
-		t.Error("SendHibernate should return a command")
-	}
-
-	// Execute the command and verify it returns a message
-	result := cmd()
-	if result == nil {
-		t.Error("Command should return a hibernate message")
 	}
 }
 

--- a/tests/tui_test.go
+++ b/tests/tui_test.go
@@ -1222,117 +1222,230 @@ func TestTUIPauseResumeWithRunningLoop(t *testing.T) {
 
 // ============================================================================
 // Tests: Per-Loop Stats in Tmux Status Bar (Spec 19)
+//
+// Per-loop tokens and elapsed time are observable through the tmux status bar:
+// updateTmuxStatusBar runs once per tick and renders
+// "[repo | branch | loop: N/M, tokens: X, elapsed: HH:MM:SS]" for the CURRENT
+// loop iteration (never the cumulative session). These tests drive a model with
+// a mocked clock and read back tui.FakeStatusBarForTest.LastContent.
 // ============================================================================
 
-// TestSendLoopStartedCmd tests the SendLoopStarted helper command
+// perLoopFakeClock is a mutable clock for the per-loop status bar tests.
+type perLoopFakeClock struct{ now time.Time }
+
+// advance moves the fake clock forward by d.
+func (c *perLoopFakeClock) advance(d time.Duration) { c.now = c.now.Add(d) }
+
+// newPerLoopStatusBarModel builds a ready model wired to a fake tmux status bar
+// and a mocked clock. The clock is installed before tui.NewModel() so both the
+// session start time and the loop start time are the clock's zero point.
+// Pass a non-nil loop to enable the pause/resume hotkeys; it is attached before
+// the tea.WindowSizeMsg because the model is copied by value on every Update.
+// Callers must `defer tui.SetTimeNowForTest(time.Now)`.
+func newPerLoopStatusBarModel(l *loop.Loop) (tui.Model, *tui.FakeStatusBarForTest, *perLoopFakeClock) {
+	clock := &perLoopFakeClock{now: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)}
+	tui.SetTimeNowForTest(func() time.Time { return clock.now })
+
+	model := tui.NewModel()
+	if l != nil {
+		model.SetLoop(l)
+	}
+	model.SetGitContext("ralph", "main")
+	model.SetLoopProgress(2, 5)
+	fakeBar := &tui.FakeStatusBarForTest{}
+	model.SetTmuxStatusBar(fakeBar)
+	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+	return model, fakeBar, clock
+}
+
+// tickPerLoopBar drives one tick and returns the content pushed to the bar.
+func tickPerLoopBar(m tui.Model, bar *tui.FakeStatusBarForTest) (tui.Model, string) {
+	m, _ = updateModel(m, tui.TickMsgForTest())
+	return m, bar.LastContent
+}
+
+// perLoopBar renders the expected status bar content for the fixture model.
+func perLoopBar(tokens, elapsed string) string {
+	return "[ralph | main | loop: 2/5, tokens: " + tokens + ", elapsed: " + elapsed + "]"
+}
+
+// TestSendLoopStartedCmd tests that SendLoopStarted returns a command whose
+// message resets both per-loop counters visible on the tmux status bar.
 func TestSendLoopStartedCmd(t *testing.T) {
+	defer tui.SetTimeNowForTest(time.Now)
+	model, bar, clock := newPerLoopStatusBarModel(nil)
+
+	// Accumulate per-loop state: 12k tokens over 30 seconds.
+	model, _ = updateModel(model, tui.SendLoopStatsUpdate(12000)())
+	clock.advance(30 * time.Second)
+	model, got := tickPerLoopBar(model, bar)
+	if want := perLoopBar("12k", "00:00:30"); got != want {
+		t.Fatalf("Precondition: status bar = %q, want %q", got, want)
+	}
+
 	cmd := tui.SendLoopStarted()
 	if cmd == nil {
-		t.Error("SendLoopStarted should return a command")
+		t.Fatal("SendLoopStarted should return a command")
 	}
-	result := cmd()
-	if result == nil {
-		t.Error("Command should return a loopStartedMsg")
+	msg := cmd()
+	if msg == nil {
+		t.Fatal("SendLoopStarted's command should produce a loopStartedMsg")
+	}
+
+	// Feeding that message in must reset both per-loop tokens and elapsed.
+	model, _ = updateModel(model, msg)
+	_, got = tickPerLoopBar(model, bar)
+	if want := perLoopBar("0", "00:00:00"); got != want {
+		t.Errorf("After loopStartedMsg: status bar = %q, want %q", got, want)
 	}
 }
 
-// TestSendLoopStatsUpdateCmd tests the SendLoopStatsUpdate helper command
+// TestSendLoopStatsUpdateCmd tests that SendLoopStatsUpdate returns a command
+// whose message sets the per-loop token count shown on the tmux status bar.
 func TestSendLoopStatsUpdateCmd(t *testing.T) {
+	defer tui.SetTimeNowForTest(time.Now)
+	model, bar, _ := newPerLoopStatusBarModel(nil)
+
+	model, got := tickPerLoopBar(model, bar)
+	if want := perLoopBar("0", "00:00:00"); got != want {
+		t.Fatalf("Precondition: status bar = %q, want %q", got, want)
+	}
+
 	cmd := tui.SendLoopStatsUpdate(12345)
 	if cmd == nil {
-		t.Error("SendLoopStatsUpdate should return a command")
+		t.Fatal("SendLoopStatsUpdate should return a command")
 	}
-	result := cmd()
-	if result == nil {
-		t.Error("Command should return a loopStatsUpdateMsg")
+	msg := cmd()
+	if msg == nil {
+		t.Fatal("SendLoopStatsUpdate's command should produce a loopStatsUpdateMsg")
+	}
+
+	// 12345 tokens render through stats.FormatTokens as "12.3k".
+	model, _ = updateModel(model, msg)
+	_, got = tickPerLoopBar(model, bar)
+	if want := perLoopBar("12.3k", "00:00:00"); got != want {
+		t.Errorf("After loopStatsUpdateMsg: status bar = %q, want %q", got, want)
 	}
 }
 
-// TestPerLoopTokensResetOnNewLoop tests that per-loop tokens reset when a new loop starts
+// TestPerLoopTokensResetOnNewLoop tests that the token count on the tmux status
+// bar drops back to zero when a new loop iteration starts.
 func TestPerLoopTokensResetOnNewLoop(t *testing.T) {
-	model := tui.NewModel()
-	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+	defer tui.SetTimeNowForTest(time.Now)
+	model, bar, _ := newPerLoopStatusBarModel(nil)
 
-	// Set loop stats to some value
-	cmd := tui.SendLoopStatsUpdate(50000)
-	model, _ = updateModel(model, cmd())
+	model, _ = updateModel(model, tui.SendLoopStatsUpdate(50000)())
+	model, got := tickPerLoopBar(model, bar)
+	if want := perLoopBar("50k", "00:00:00"); got != want {
+		t.Fatalf("With 50000 per-loop tokens: status bar = %q, want %q", got, want)
+	}
 
-	// Signal a new loop started
-	cmd = tui.SendLoopStarted()
-	model, _ = updateModel(model, cmd())
+	model, _ = updateModel(model, tui.SendLoopStarted()())
+	model, got = tickPerLoopBar(model, bar)
+	if want := perLoopBar("0", "00:00:00"); got != want {
+		t.Fatalf("After new loop started: status bar = %q, want %q", got, want)
+	}
 
-	// Per-loop tokens should be reset to 0
-	// Verify by sending another loop stats update with a small value
-	cmd = tui.SendLoopStatsUpdate(100)
-	model, _ = updateModel(model, cmd())
-
-	// The model should work without errors after reset
-	view := model.View()
-	if view == "" {
-		t.Error("View should render after per-loop stats reset")
+	// The counter keeps working after the reset: it counts from zero again.
+	model, _ = updateModel(model, tui.SendLoopStatsUpdate(100)())
+	_, got = tickPerLoopBar(model, bar)
+	if want := perLoopBar("100", "00:00:00"); got != want {
+		t.Errorf("After 100 tokens in the new loop: status bar = %q, want %q", got, want)
 	}
 }
 
-// TestPerLoopTimerResetsOnNewLoop tests that per-loop elapsed timer resets when a new loop starts
+// TestPerLoopTimerResetsOnNewLoop tests that the elapsed time on the tmux status
+// bar is per-loop, not per-session: it restarts at 00:00:00 on a new iteration
+// while the session's "Total Time" in the TUI footer keeps counting.
 func TestPerLoopTimerResetsOnNewLoop(t *testing.T) {
-	model := tui.NewModel()
-	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+	defer tui.SetTimeNowForTest(time.Now)
+	model, bar, clock := newPerLoopStatusBarModel(nil)
 
-	// Wait a bit so the loop timer accumulates
-	time.Sleep(50 * time.Millisecond)
+	clock.advance(65 * time.Second)
+	model, got := tickPerLoopBar(model, bar)
+	if want := perLoopBar("0", "00:01:05"); got != want {
+		t.Fatalf("After 65s in the first loop: status bar = %q, want %q", got, want)
+	}
 
-	// Signal a new loop started — should reset per-loop timer
-	cmd := tui.SendLoopStarted()
-	model, _ = updateModel(model, cmd())
+	// A new loop iteration begins 65s into the session.
+	model, _ = updateModel(model, tui.SendLoopStarted()())
+	model, got = tickPerLoopBar(model, bar)
+	if want := perLoopBar("0", "00:00:00"); got != want {
+		t.Fatalf("A new loop must restart the bar's clock: status bar = %q, want %q", got, want)
+	}
+	// ...while the session total is unaffected — that is the per-loop/session split.
+	if view := model.View(); !strings.Contains(view, "00:01:05") {
+		t.Error("Footer 'Total Time' should still show the 65s session elapsed after a new loop starts")
+	}
 
-	// The per-loop timer should now be near-zero (just reset)
-	// We can't directly inspect it, but the view should render without error
-	view := model.View()
-	if view == "" {
-		t.Error("View should render after per-loop timer reset")
+	clock.advance(5 * time.Second)
+	model, got = tickPerLoopBar(model, bar)
+	if want := perLoopBar("0", "00:00:05"); got != want {
+		t.Errorf("5s into the new loop: status bar = %q, want %q", got, want)
+	}
+	if view := model.View(); !strings.Contains(view, "00:01:10") {
+		t.Error("Footer 'Total Time' should show 00:01:10 while the bar shows 00:00:05")
 	}
 }
 
-// TestPerLoopTimerFreezesOnPause tests that the per-loop timer freezes when paused
+// TestPerLoopTimerFreezesOnPause tests that pausing with 'p' freezes the per-loop
+// elapsed time on the tmux status bar even as the mocked clock keeps moving.
 func TestPerLoopTimerFreezesOnPause(t *testing.T) {
-	model := tui.NewModel()
+	defer tui.SetTimeNowForTest(time.Now)
 	l := loop.New(loop.Config{Iterations: 5, Prompt: "test"})
-	model.SetLoop(l)
-	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+	model, bar, clock := newPerLoopStatusBarModel(l)
 
-	// Pause
-	keyP := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}}
-	model, _ = updateModel(model, keyP)
+	clock.advance(10 * time.Second)
+	model, got := tickPerLoopBar(model, bar)
+	if want := perLoopBar("0", "00:00:10"); got != want {
+		t.Fatalf("Before pause: status bar = %q, want %q", got, want)
+	}
 
-	// After pausing, two consecutive views should be identical
-	// (both total and per-loop timers are frozen)
-	view1 := model.View()
-	time.Sleep(50 * time.Millisecond)
-	view2 := model.View()
+	// Pause at +10s: the per-loop timer freezes at 00:00:10.
+	model, _ = updateModel(model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
 
-	if view1 != view2 {
-		t.Error("With paused timers (including per-loop), consecutive views should be identical")
+	clock.advance(35 * time.Second)
+	model, got = tickPerLoopBar(model, bar)
+	if want := perLoopBar("0", "00:00:10"); got != want {
+		t.Fatalf("35s after pausing: status bar = %q, want %q (frozen)", got, want)
+	}
+
+	clock.advance(2 * time.Minute)
+	_, got = tickPerLoopBar(model, bar)
+	if want := perLoopBar("0", "00:00:10"); got != want {
+		t.Errorf("2m35s after pausing: status bar = %q, want %q (still frozen)", got, want)
 	}
 }
 
-// TestPerLoopTimerResumesAfterPause tests that the per-loop timer resumes after unpause
+// TestPerLoopTimerResumesAfterPause tests that resuming with 'r' continues the
+// per-loop timer from the frozen value rather than restarting or back-filling
+// the paused interval: 10s before the pause + 10s after the resume = 00:00:20.
 func TestPerLoopTimerResumesAfterPause(t *testing.T) {
-	model := tui.NewModel()
+	defer tui.SetTimeNowForTest(time.Now)
 	l := loop.New(loop.Config{Iterations: 5, Prompt: "test"})
-	model.SetLoop(l)
-	model, _ = updateModel(model, tea.WindowSizeMsg{Width: 120, Height: 40})
+	model, bar, clock := newPerLoopStatusBarModel(l)
 
-	// Pause then resume
-	keyP := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}}
-	model, _ = updateModel(model, keyP)
+	// Pause at +10s (10s accumulated), resume at +30s (20s spent paused).
+	clock.advance(10 * time.Second)
+	model, _ = updateModel(model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'p'}})
 
-	keyR := tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}}
-	model, _ = updateModel(model, keyR)
+	clock.advance(20 * time.Second)
+	model, got := tickPerLoopBar(model, bar)
+	if want := perLoopBar("0", "00:00:10"); got != want {
+		t.Fatalf("While paused: status bar = %q, want %q", got, want)
+	}
 
-	// After resume, view should render without error
-	view := model.View()
-	if view == "" {
-		t.Error("View should render after resuming per-loop timer")
+	model, _ = updateModel(model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'r'}})
+	model, got = tickPerLoopBar(model, bar)
+	if want := perLoopBar("0", "00:00:10"); got != want {
+		t.Fatalf("At the instant of resume: status bar = %q, want %q", got, want)
+	}
+
+	// 10s after the resume: the 20s paused interval is never counted.
+	clock.advance(10 * time.Second)
+	_, got = tickPerLoopBar(model, bar)
+	if want := perLoopBar("0", "00:00:20"); got != want {
+		t.Errorf("10s after resuming: status bar = %q, want %q", got, want)
 	}
 }
 

--- a/tests/tui_test.go
+++ b/tests/tui_test.go
@@ -1994,8 +1994,10 @@ func TestDeletePlanHotkeyInHotkeyBar(t *testing.T) {
 //
 // The fourth footer panel shows what the loop is actually running with:
 // "Model:", "Effort:" and "Mode:" rows. Known model tiers collapse to their
-// short name, unknown ids render verbatim, and an empty flag reads "default"
-// (i.e. whatever the claude CLI resolves on its own).
+// short name and unknown ids render verbatim; an unset model reads "default"
+// (whatever the claude CLI resolves on its own, refined once the stream reports
+// it). Effort has no such fallback name — the levels are low/medium/high/xhigh/
+// max — so an unresolved one reads "-", the same placeholder the Mode row uses.
 // ============================================================================
 
 // setupModelDetailsModel builds a ready model with the given --model/--effort
@@ -2140,23 +2142,29 @@ func TestModelDetailsCollapsesSonnetTier(t *testing.T) {
 	if strings.Contains(panel, "claude-sonnet-4-6") {
 		t.Errorf("Panel should not print the full model id, got panel:\n%s", panel)
 	}
-	if !panelHasRow(rows, "Effort: default") {
-		t.Errorf("Panel should show 'Effort: default' when --effort was not passed, got rows: %q", rows)
+	if !panelHasRow(rows, "Effort: -") {
+		t.Errorf("Panel should show 'Effort: -' when no effort level could be resolved, got rows: %q", rows)
 	}
 }
 
-// TestModelDetailsEmptyFlagsShowDefault tests that an unset model and effort both
-// render as "default" (the claude CLI decides).
-func TestModelDetailsEmptyFlagsShowDefault(t *testing.T) {
+// TestModelDetailsUnresolvedEffortIsNotDefault tests that an unresolved effort
+// renders as the "-" placeholder, not as "default". The claude CLI's levels are
+// low/medium/high/xhigh/max; "default" is not one of them, so showing it reads
+// as a level that does not exist.
+func TestModelDetailsUnresolvedEffortIsNotDefault(t *testing.T) {
 	model := setupModelDetailsModel("", "")
 
-	// Both rows must fall back independently — asserted as complete rows rather
-	// than by counting "default" occurrences across the whole view.
+	// The model row keeps its own "default" fallback (the stream refines it
+	// later), so the rows must be asserted independently rather than by counting
+	// "default" occurrences across the whole view.
 	rows := modelDetailsRows(t, model.View())
-	for _, want := range []string{"Model: default", "Effort: default"} {
+	for _, want := range []string{"Model: default", "Effort: -"} {
 		if !panelHasRow(rows, want) {
 			t.Errorf("Model Details panel should contain the row %q, got rows: %q", want, rows)
 		}
+	}
+	if panelHasRow(rows, "Effort: default") {
+		t.Errorf("'default' is not an effort level and must not render as one, got rows: %q", rows)
 	}
 }
 
@@ -2235,5 +2243,71 @@ func TestModelDetailsEmptyStreamModelIgnored(t *testing.T) {
 	}
 	if panelHasRow(rows, "Model: default") {
 		t.Errorf("An empty model update should not reset the model row to 'default', got rows: %q", rows)
+	}
+}
+
+// TestModelDetailsTranscriptEffortOverridesFlag tests that the level read back
+// from the session transcript replaces the one Ralph resolved up front. The
+// transcript is what the CLI actually ran at, so it wins even over --effort —
+// enterprise managed settings can override the flag on the command line.
+func TestModelDetailsTranscriptEffortOverridesFlag(t *testing.T) {
+	model := setupModelDetailsModel("claude-opus-4-8", "high")
+
+	cmd := tui.SendEffortUpdate("max")
+	model, _ = updateModel(model, cmd())
+
+	view := model.View()
+	panel := modelDetailsPanel(t, view)
+	rows := modelDetailsRows(t, view)
+
+	if !panelHasRow(rows, "Effort: max") {
+		t.Errorf("Panel should show the transcript's effort level, got rows: %q", rows)
+	}
+	if strings.Contains(panel, "high") {
+		t.Errorf("Panel should no longer show the flag's effort level 'high', got panel:\n%s", panel)
+	}
+	// And: the model row is untouched by an effort update.
+	if !panelHasRow(rows, "Model: opus") {
+		t.Errorf("Model should persist across an effort update, got rows: %q", rows)
+	}
+}
+
+// TestModelDetailsUnresolvedEffortRefinedByTranscript tests the case the
+// transcript readback exists for: nothing configured a level up front, so the
+// panel starts at "-" and fills in once the session reports one.
+func TestModelDetailsUnresolvedEffortRefinedByTranscript(t *testing.T) {
+	model := setupModelDetailsModel("", "")
+
+	if rows := modelDetailsRows(t, model.View()); !panelHasRow(rows, "Effort: -") {
+		t.Fatalf("Panel should start at the '-' placeholder, got rows: %q", rows)
+	}
+
+	cmd := tui.SendEffortUpdate("xhigh")
+	model, _ = updateModel(model, cmd())
+
+	rows := modelDetailsRows(t, model.View())
+	if !panelHasRow(rows, "Effort: xhigh") {
+		t.Errorf("Panel should show the effort level once the transcript reports it, got rows: %q", rows)
+	}
+	if panelHasRow(rows, "Effort: -") {
+		t.Errorf("Panel should drop the placeholder once a level is known, got rows: %q", rows)
+	}
+}
+
+// TestModelDetailsEmptyEffortUpdateIgnored tests that an empty effort update —
+// what a transcript read returns before the CLI has recorded a level — does not
+// wipe the value already resolved from the flag or settings.
+func TestModelDetailsEmptyEffortUpdateIgnored(t *testing.T) {
+	model := setupModelDetailsModel("claude-opus-4-8", "medium")
+
+	cmd := tui.SendEffortUpdate("")
+	model, _ = updateModel(model, cmd())
+
+	rows := modelDetailsRows(t, model.View())
+	if !panelHasRow(rows, "Effort: medium") {
+		t.Errorf("An empty effort update should not clear the resolved level, got rows: %q", rows)
+	}
+	if panelHasRow(rows, "Effort: -") {
+		t.Errorf("An empty effort update should not reset the row to the '-' placeholder, got rows: %q", rows)
 	}
 }

--- a/tests/tui_test.go
+++ b/tests/tui_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/cloudosai/ralph-go/internal/loop"
@@ -1918,14 +1919,95 @@ func setupModelDetailsModel(model, effort string) tui.Model {
 	return m
 }
 
+// modelDetailsPanel returns only the "Model Details" footer panel region of a
+// rendered view.
+//
+// Why this exists: the panel's values are extremely short ("opus", "high",
+// "default", "sonnet"). Asserting strings.Contains against the WHOLE view makes
+// those assertions pass or fail for the wrong reason as soon as any other part
+// of the view — another footer row, the hotkey bar, an activity message, a plan
+// line — happens to contain the same characters. Two concrete traps:
+// "high" is a substring of "xhigh" (so a whole-view check cannot distinguish
+// --effort high from --effort xhigh), and a negative check like
+// !Contains(view, "opus") breaks the moment an assistant message mentions opus.
+// Scoping every assertion to this panel makes short substrings unambiguous.
+//
+// Model Details is the RIGHTMOST footer panel, so everything from its left
+// border column through end-of-line belongs to it. Box-drawing runes (│ ╭ ─ ╰)
+// are multi-byte UTF-8, so columns are counted in RUNES, never bytes.
+func modelDetailsPanel(t *testing.T, view string) string {
+	t.Helper()
+
+	const title = "Model Details"
+
+	lines := strings.Split(view, "\n")
+	titleLine := -1
+	startCol := 0
+	for i, line := range lines {
+		byteIdx := strings.Index(line, title)
+		if byteIdx == -1 {
+			continue
+		}
+		titleLine = i
+		// strings.Index gives a BYTE offset; convert it to a rune column.
+		// The panel's left border plus padding ("│ ") sit two runes before
+		// the title, so that is where the panel actually starts.
+		startCol = utf8.RuneCountInString(line[:byteIdx]) - 2
+		if startCol < 0 {
+			startCol = 0
+		}
+		break
+	}
+	if titleLine == -1 {
+		t.Fatalf("%q not found in rendered view:\n%s", title, view)
+	}
+
+	var panel []string
+	for _, line := range lines[titleLine:] {
+		runes := []rune(line)
+		if len(runes) <= startCol {
+			// Too short to reach the panel's column — e.g. the hotkey bar
+			// underneath the footer. Not part of the panel.
+			continue
+		}
+		panel = append(panel, string(runes[startCol:]))
+	}
+	return strings.Join(panel, "\n")
+}
+
+// modelDetailsRows returns the Model Details panel's text rows with the border
+// runes and padding stripped, so tests can assert on COMPLETE rows
+// ("Effort: high") instead of loose substrings ("high").
+func modelDetailsRows(t *testing.T, view string) []string {
+	t.Helper()
+
+	var rows []string
+	for _, line := range strings.Split(modelDetailsPanel(t, view), "\n") {
+		rows = append(rows, strings.Trim(line, "│ "))
+	}
+	return rows
+}
+
+// panelHasRow reports whether one of the panel's rows is exactly want.
+func panelHasRow(rows []string, want string) bool {
+	for _, row := range rows {
+		if row == want {
+			return true
+		}
+	}
+	return false
+}
+
 // TestModelDetailsPanelTitleRendered tests that the fourth footer panel is titled
 // "Model Details".
 func TestModelDetailsPanelTitleRendered(t *testing.T) {
 	model := setupModelDetailsModel("", "")
 
-	view := model.View()
-	if !strings.Contains(view, "Model Details") {
-		t.Error("View should contain the 'Model Details' panel title")
+	// modelDetailsRows t.Fatalf's if the title is missing entirely; asserting
+	// the title is the panel's first row also pins it to the panel header.
+	rows := modelDetailsRows(t, model.View())
+	if len(rows) == 0 || rows[0] != "Model Details" {
+		t.Errorf("Expected 'Model Details' as the panel's first row, got rows: %q", rows)
 	}
 }
 
@@ -1935,14 +2017,22 @@ func TestModelDetailsShowsOpusTierAndEffort(t *testing.T) {
 	model := setupModelDetailsModel("claude-opus-4-8", "high")
 
 	view := model.View()
-	for _, want := range []string{"Model:", "opus", "Effort:", "high"} {
-		if !strings.Contains(view, want) {
-			t.Errorf("View should contain %q in the Model Details panel", want)
+	panel := modelDetailsPanel(t, view)
+	rows := modelDetailsRows(t, view)
+
+	for _, want := range []string{"Model: opus", "Effort: high"} {
+		if !panelHasRow(rows, want) {
+			t.Errorf("Model Details panel should contain the row %q, got rows: %q", want, rows)
 		}
 	}
+	// "high" is a substring of "xhigh", so the exact-row check above is only
+	// meaningful alongside this: the panel must not be showing xhigh.
+	if strings.Contains(panel, "xhigh") {
+		t.Errorf("Effort 'high' should not render as 'xhigh', got panel:\n%s", panel)
+	}
 	// The verbose id should be collapsed, not printed in full.
-	if strings.Contains(view, "claude-opus-4-8") {
-		t.Error("View should collapse 'claude-opus-4-8' to the tier name 'opus'")
+	if strings.Contains(panel, "claude-opus-4-8") {
+		t.Errorf("Panel should collapse 'claude-opus-4-8' to the tier name 'opus', got panel:\n%s", panel)
 	}
 }
 
@@ -1952,11 +2042,17 @@ func TestModelDetailsCollapsesSonnetTier(t *testing.T) {
 	model := setupModelDetailsModel("claude-sonnet-4-6", "")
 
 	view := model.View()
-	if !strings.Contains(view, "sonnet") {
-		t.Error("View should collapse 'claude-sonnet-4-6' to the tier name 'sonnet'")
+	panel := modelDetailsPanel(t, view)
+	rows := modelDetailsRows(t, view)
+
+	if !panelHasRow(rows, "Model: sonnet") {
+		t.Errorf("Panel should collapse 'claude-sonnet-4-6' to the tier name 'sonnet', got rows: %q", rows)
 	}
-	if !strings.Contains(view, "default") {
-		t.Error("View should show 'default' effort when --effort was not passed")
+	if strings.Contains(panel, "claude-sonnet-4-6") {
+		t.Errorf("Panel should not print the full model id, got panel:\n%s", panel)
+	}
+	if !panelHasRow(rows, "Effort: default") {
+		t.Errorf("Panel should show 'Effort: default' when --effort was not passed, got rows: %q", rows)
 	}
 }
 
@@ -1965,14 +2061,13 @@ func TestModelDetailsCollapsesSonnetTier(t *testing.T) {
 func TestModelDetailsEmptyFlagsShowDefault(t *testing.T) {
 	model := setupModelDetailsModel("", "")
 
-	view := model.View()
-	if !strings.Contains(view, "Model:") || !strings.Contains(view, "Effort:") {
-		t.Fatal("View should contain the 'Model:' and 'Effort:' rows")
-	}
-	// "default" is only ever produced by the model and effort rows, so both
-	// rows falling back means exactly two occurrences.
-	if got := strings.Count(view, "default"); got != 2 {
-		t.Errorf("Expected both the model and effort rows to read 'default' (2 occurrences), got %d", got)
+	// Both rows must fall back independently — asserted as complete rows rather
+	// than by counting "default" occurrences across the whole view.
+	rows := modelDetailsRows(t, model.View())
+	for _, want := range []string{"Model: default", "Effort: default"} {
+		if !panelHasRow(rows, want) {
+			t.Errorf("Model Details panel should contain the row %q, got rows: %q", want, rows)
+		}
 	}
 }
 
@@ -1982,11 +2077,16 @@ func TestModelDetailsUnknownModelRendersVerbatim(t *testing.T) {
 	model := setupModelDetailsModel("zeta-9", "low")
 
 	view := model.View()
-	if !strings.Contains(view, "zeta-9") {
-		t.Error("View should render an unrecognized model id verbatim")
+	rows := modelDetailsRows(t, view)
+
+	if !panelHasRow(rows, "Model: zeta-9") {
+		t.Errorf("Panel should render an unrecognized model id verbatim, got rows: %q", rows)
 	}
-	if strings.Contains(view, "Model: default") {
-		t.Error("An unrecognized model id should not fall back to 'default'")
+	if panelHasRow(rows, "Model: default") {
+		t.Errorf("An unrecognized model id should not fall back to 'default', got rows: %q", rows)
+	}
+	if !panelHasRow(rows, "Effort: low") {
+		t.Errorf("Panel should still show the configured effort, got rows: %q", rows)
 	}
 }
 
@@ -1995,11 +2095,14 @@ func TestModelDetailsEffortLowercased(t *testing.T) {
 	model := setupModelDetailsModel("", "XHIGH")
 
 	view := model.View()
-	if !strings.Contains(view, "xhigh") {
-		t.Error("View should lowercase the effort level ('XHIGH' -> 'xhigh')")
+	panel := modelDetailsPanel(t, view)
+	rows := modelDetailsRows(t, view)
+
+	if !panelHasRow(rows, "Effort: xhigh") {
+		t.Errorf("Panel should lowercase the effort level ('XHIGH' -> 'xhigh'), got rows: %q", rows)
 	}
-	if strings.Contains(view, "XHIGH") {
-		t.Error("View should not show the raw uppercase effort level")
+	if strings.Contains(panel, "XHIGH") {
+		t.Errorf("Panel should not show the raw uppercase effort level, got panel:\n%s", panel)
 	}
 }
 
@@ -2012,11 +2115,20 @@ func TestModelDetailsStreamModelOverridesFlag(t *testing.T) {
 	model, _ = updateModel(model, cmd())
 
 	view := model.View()
-	if !strings.Contains(view, "haiku") {
-		t.Error("View should show 'haiku' after the stream reports the effective model")
+	panel := modelDetailsPanel(t, view)
+	rows := modelDetailsRows(t, view)
+
+	if !panelHasRow(rows, "Model: haiku") {
+		t.Errorf("Panel should show 'haiku' after the stream reports the effective model, got rows: %q", rows)
 	}
-	if strings.Contains(view, "opus") {
-		t.Error("View should no longer show the flag model 'opus' after a stream model update")
+	// Scoped to the panel: an activity message mentioning "opus" must not be
+	// able to fail this.
+	if strings.Contains(panel, "opus") {
+		t.Errorf("Panel should no longer show the flag model 'opus' after a stream model update, got panel:\n%s", panel)
+	}
+	// And: effort is untouched by a model update.
+	if !panelHasRow(rows, "Effort: high") {
+		t.Errorf("Effort should persist across a model update, got rows: %q", rows)
 	}
 }
 
@@ -2028,11 +2140,11 @@ func TestModelDetailsEmptyStreamModelIgnored(t *testing.T) {
 	cmd := tui.SendModelUpdate("")
 	model, _ = updateModel(model, cmd())
 
-	view := model.View()
-	if !strings.Contains(view, "opus") {
-		t.Error("An empty model update should not clear the previously-set model")
+	rows := modelDetailsRows(t, model.View())
+	if !panelHasRow(rows, "Model: opus") {
+		t.Errorf("An empty model update should not clear the previously-set model, got rows: %q", rows)
 	}
-	if strings.Contains(view, "Model: default") {
-		t.Error("An empty model update should not reset the model row to 'default'")
+	if panelHasRow(rows, "Model: default") {
+		t.Errorf("An empty model update should not reset the model row to 'default', got rows: %q", rows)
 	}
 }

--- a/tests/tui_test.go
+++ b/tests/tui_test.go
@@ -2036,4 +2036,3 @@ func TestModelDetailsEmptyStreamModelIgnored(t *testing.T) {
 		t.Error("An empty model update should not reset the model row to 'default'")
 	}
 }
-


### PR DESCRIPTION
Eight commits reworking the TUI footer, fixing two state/encoding bugs, and tightening the tests that were passing for the wrong reasons.

## Features

**Model Details footer panel** (`b06b150`) — replaces the Task Progress panel, which duplicated the plan panel above it and did it worse (scraping counts from `IMPLEMENTATION_PLAN.md` and regex-matching `TASK N` out of assistant text). The plan panel is now the single source of truth for task progress; this quarter shows model tier, effort level, and mode instead. Model resolution reads `--model` first, then refines with the effective model reported by the stream — `Parser.GetModel` now also reads the top-level `model` field on the system/init line, not just `message.model`. Subagent messages are skipped since they may run a different model. Tier matching moved into the exported `stats.ModelTier` so the TUI and the pricing table share one implementation. The orphaned scrape pipeline is removed rather than left dangling.

**Per-loop tokens and elapsed in the tmux status bar** (`14d5f6d`) — finishes Spec 19, which had shipped only half: the per-loop state machine was maintained correctly but nothing read it (`getLoopElapsed()` had zero callers) while `updateTmuxStatusBar` rendered session totals. `FormatStatusRight` gains a tokens field and omits empty ones, fixing a dangling `uptime: ` label with no value; `uptime:` becomes `elapsed:` since the value is per-iteration. Session totals stay in the footer, so the two surfaces complement rather than duplicate.

## Fixes

**Hibernate state had two sources of truth** (`95d6267`) — the loop auto-wakes when a rate-limit deadline passes and clears its own flag, but the TUI kept a second copy cleared only on `r`/`s` keypress. Every automatic wake left the tmux bar pinned to `RATE LIMITED 00:00` and suppressed the thinking indicator for the rest of the session, while `renderLayout`/`renderFooter` read the loop directly and recovered — so the TUI contradicted itself: border RUNNING, tmux bar RATE LIMITED. `*loop.Loop` is now the single source via `isHibernating()`/`hibernateRemaining()`; the duplicate is deleted rather than synced, which orphans `hibernateMsg`, `tui.SendHibernate`, and nine redundant `program.Send` calls whose sites already called `Hibernate()` directly.

**UTF-8 truncation in the parser** (`8549e22`) — `ExtractFilePathFromInput` cut Bash commands at byte 50 and the `tool_use` preview cut JSON at byte 150, both splitting multibyte runes. The command path is user-visible (rendered in the TUI tool row), so non-ASCII commands showed as mojibake. Both route through the existing rune-safe `truncate` helper.

**The Model Details panel named an effort level that does not exist** (`7b895a7`) — the Effort row read "default" whenever `--effort` was not passed, but the claude CLI's levels are low/medium/high/xhigh/max. It was also hiding a knowable value: the level is usually configured, just not by Ralph's flag. Unlike the model, effort cannot be read off the stream — every event of a real `--output-format stream-json` run (`system/init`, `assistant`, `rate_limit_event`, `result`) was checked against claude 2.1.226 and none carry it. So it is resolved from the two sources that do know, mirroring how the model row already works: `config.ResolveEffort` reads `--effort`, else `effortLevel` walked down the settings chain in the CLI's own precedence order (project-local → project → user), available from startup; `config.TranscriptEffort` then reads back the level the CLI recorded on the session's assistant records in `~/.claude/projects`, which is ground truth a few seconds in because it reflects precedence Ralph does not reimplement — notably enterprise managed settings, which outrank even the command-line flag. The readback hangs off a new `trackSession`, replacing the identical `GetSessionID`/`SetSessionID` blocks at the three TUI message pumps: the loop already stores the session ID, so "the session changed" is free and the bounded (~30s) background poll starts once per session rather than once per system message. Sessions are located by globbing the session ID across project directories rather than reproducing the CLI's cwd→directory-name mangling, and a non-UUID session ID is refused before it can reach the glob or the path. Both resolvers are display-only — `claude --effort` still receives `Config.Effort` verbatim — and the transcript path fails silently, since its format is internal to the CLI. Only when no source configures a level at all does the row fall back to the `-` placeholder the Mode row in the same panel already uses.

## Tests

- `aa4b610` — Model Details tests asserted `strings.Contains` against the *whole* view with substrings as short as `"opus"` and `"high"`. Two were latently broken: `"high"` is a substring of `"xhigh"`, and `!Contains(view, "opus")` breaks on any assistant message mentioning opus. Now sliced to the rightmost footer panel by rune column and asserted on complete rows.
- `755be0b` — `extractFooterSection` hand-rolled a prefix scan that silently returned the start of the view on a missing keyword, and sliced by byte offset, so its diagnostic output could itself be mojibake.
- Vacuous tests whose only assertion was `view != ""` are replaced with real content assertions.

Behavior changes are mutation-tested; each commit message records which mutants fail how many tests.

## Housekeeping

`74a013c` is `gofmt -w` across 11 files (whitespace only), and `b73a09d` corrects a stale `CLAUDE.md` reference to the deleted `parseTaskCounts`, documents the gofmt gate, and notes that `make test` runs only `./tests`, skipping `main_test.go`.

## Verification

`go build`, `go vet ./...`, and `gofmt -l .` are clean; `go test ./tests/ ./cmd/ralph/` passes. Footer rendered at widths 80/100/120/160 with no wrapping.

## Release

`daf3fea` bumps `config.Version` to **v2026.8.8** (CalVer, off `v2026.7.3`). The release job in `ci.yml` fires only on a `v*` tag push, so merging this PR does not publish on its own — tag `v2026.8.8` on `main` after merge and CI builds the binaries, cuts the GitHub Release, and publishes the Homebrew formula.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

